### PR TITLE
CCS-30 avoid FX fee for same-currency context conversions

### DIFF
--- a/CurrencyConverter Extension/SafariExtensionHandler.swift
+++ b/CurrencyConverter Extension/SafariExtensionHandler.swift
@@ -49,15 +49,20 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                     
                     //Add credit card FX rate
                     let fxIndex = sharedUserDefaults.value(forKey: "fxRateIndex") as! Int? ?? 1
-                    let fxRate = LegacyContextMenuFXFeePolicy.rate(for: fxIndex)
-                    
-                    let price = result * (1 + fxRate)
+                    let calculation = LegacyContextMenuCalculation.calculate(
+                        rawResult: result,
+                        unit: unit,
+                        sourceCurrency: convertFromSym,
+                        targetCurrency: convertToSym,
+                        feeIndex: fxIndex
+                    )
+                    let price = calculation.finalAmount
                     
                     let formatter = ConvertPasteboardFormatter.init(fromSymbol: convertFromSym, fromAmount: unit, toSymbol: convertToSym, toAmount: price)
                     let formattingIndex = sharedUserDefaults.value(forKey: "FormatIndex") as? Int ?? 0
                     let lastCurrencyExchangeStr = formatter.getFormattedString(formatIndex: formattingIndex)
                     validationHandler(false, lastCurrencyExchangeStr)
-                    let lastResult = LastResult(resultString: lastCurrencyExchangeStr, convertFrom: convertFromSym, convertTo: convertToSym, units: unit, fxRate: fxRate, ratio: result / unit)
+                    let lastResult = LastResult(resultString: lastCurrencyExchangeStr, convertFrom: convertFromSym, convertTo: convertToSym, units: unit, fxRate: calculation.appliedFXFee, ratio: calculation.ratio)
                     sharedUserDefaults.set(try? LastResultPersistence.encode(lastResult), forKey: "lastResult")
                     
                 }

--- a/CurrencyConverterTests/CCS34CharacterizationTests.swift
+++ b/CurrencyConverterTests/CCS34CharacterizationTests.swift
@@ -77,6 +77,58 @@ final class CCS34PersistenceCharacterizationTests: XCTestCase {
         XCTAssertEqual(LegacyContextMenuFXFeePolicy.rate(for: 99), 0)
     }
 
+    func testSameCurrencyContextMenuIgnoresSelectedFXFee() {
+        for index in [0, 1, 2] {
+            let calculation = LegacyContextMenuCalculation.calculate(
+                rawResult: 100,
+                unit: 100,
+                sourceCurrency: "USD",
+                targetCurrency: "USD",
+                feeIndex: index
+            )
+
+            XCTAssertEqual(calculation.finalAmount, 100, accuracy: 0.0001)
+            XCTAssertEqual(calculation.appliedFXFee, 0, accuracy: 0.0001)
+            XCTAssertEqual(calculation.ratio, 1, accuracy: 0.0001)
+        }
+    }
+
+    func testCrossCurrencyContextMenuPreservesSelectedFXFee() {
+        let calculation = LegacyContextMenuCalculation.calculate(
+            rawResult: 50,
+            unit: 100,
+            sourceCurrency: "USD",
+            targetCurrency: "TWD",
+            feeIndex: 1
+        )
+
+        XCTAssertEqual(calculation.finalAmount, 50.75, accuracy: 0.0001)
+        XCTAssertEqual(calculation.appliedFXFee, 0.015, accuracy: 0.0001)
+        XCTAssertEqual(calculation.ratio, 0.5, accuracy: 0.0001)
+    }
+
+    func testSameCurrencyLastResultRoundTripsCalculationValues() throws {
+        let calculation = LegacyContextMenuCalculation.calculate(
+            rawResult: 100,
+            unit: 100,
+            sourceCurrency: "USD",
+            targetCurrency: "USD",
+            feeIndex: 2
+        )
+        let result = LastResult(
+            resultString: "100.00 USD",
+            convertFrom: "USD",
+            convertTo: "USD",
+            units: 100,
+            fxRate: calculation.appliedFXFee,
+            ratio: calculation.ratio
+        )
+
+        XCTAssertEqual(try LastResultPersistence.decode(LastResultPersistence.encode(result)), result)
+        XCTAssertEqual(result.fxRate, 0, accuracy: 0.0001)
+        XCTAssertEqual(result.ratio, 1, accuracy: 0.0001)
+    }
+
     func testLastResultRoundTripsThroughIsolatedDefaultsData() throws {
         let result = LastResult(resultString: "2.03 USD", convertFrom: "TWD", convertTo: "USD", units: 8, fxRate: 0.015, ratio: 0.25)
         let suiteName = "CCS34-last-result-\(UUID().uuidString)"

--- a/CurrencyConverterTests/CCS34CharacterizationTests.swift
+++ b/CurrencyConverterTests/CCS34CharacterizationTests.swift
@@ -78,13 +78,19 @@ final class CCS34PersistenceCharacterizationTests: XCTestCase {
     }
 
     func testSameCurrencyContextMenuIgnoresSelectedFXFee() {
-        for index in [0, 1, 2] {
+        let sameCurrencyCases: [(feeIndex: Int, rawResult: Float32)] = [
+            (0, 10),
+            (1, 21),
+            (2, 33)
+        ]
+
+        for testCase in sameCurrencyCases {
             let calculation = LegacyContextMenuCalculation.calculate(
-                rawResult: 100,
+                rawResult: testCase.rawResult,
                 unit: 100,
                 sourceCurrency: "USD",
                 targetCurrency: "USD",
-                feeIndex: index
+                feeIndex: testCase.feeIndex
             )
 
             XCTAssertEqual(calculation.finalAmount, 100, accuracy: 0.0001)
@@ -94,17 +100,52 @@ final class CCS34PersistenceCharacterizationTests: XCTestCase {
     }
 
     func testCrossCurrencyContextMenuPreservesSelectedFXFee() {
-        let calculation = LegacyContextMenuCalculation.calculate(
-            rawResult: 50,
-            unit: 100,
-            sourceCurrency: "USD",
-            targetCurrency: "TWD",
-            feeIndex: 1
-        )
+        let crossCurrencyCases: [(feeIndex: Int, appliedFXFee: Float32, expectedFinalAmount: Float32)] = [
+            (0, 0, 50),
+            (1, 0.015, 50.75),
+            (2, 0.02, 51)
+        ]
 
-        XCTAssertEqual(calculation.finalAmount, 50.75, accuracy: 0.0001)
-        XCTAssertEqual(calculation.appliedFXFee, 0.015, accuracy: 0.0001)
-        XCTAssertEqual(calculation.ratio, 0.5, accuracy: 0.0001)
+        for testCase in crossCurrencyCases {
+            let calculation = LegacyContextMenuCalculation.calculate(
+                rawResult: 50,
+                unit: 100,
+                sourceCurrency: "USD",
+                targetCurrency: "TWD",
+                feeIndex: testCase.feeIndex
+            )
+
+            XCTAssertEqual(calculation.finalAmount, testCase.expectedFinalAmount, accuracy: 0.0001)
+            XCTAssertEqual(calculation.appliedFXFee, testCase.appliedFXFee, accuracy: 0.0001)
+            XCTAssertEqual(calculation.ratio, 0.5, accuracy: 0.0001)
+        }
+    }
+
+    func testCrossCurrencyContextMenuRatioDivisionBehaviorWithZeroUnits() {
+        let nonZeroRawResultForZeroUnit = [
+            LegacyContextMenuCalculation.calculate(
+                rawResult: 7,
+                unit: 0,
+                sourceCurrency: "USD",
+                targetCurrency: "TWD",
+                feeIndex: 1
+            ),
+            LegacyContextMenuCalculation.calculate(
+                rawResult: 0,
+                unit: 0,
+                sourceCurrency: "USD",
+                targetCurrency: "TWD",
+                feeIndex: 2
+            )
+        ]
+
+        XCTAssertTrue(nonZeroRawResultForZeroUnit[0].ratio.isInfinite)
+        XCTAssertEqual(nonZeroRawResultForZeroUnit[0].finalAmount, 7.105, accuracy: 0.0001)
+        XCTAssertEqual(nonZeroRawResultForZeroUnit[0].appliedFXFee, 0.015, accuracy: 0.0001)
+
+        XCTAssertTrue(nonZeroRawResultForZeroUnit[1].ratio.isNaN)
+        XCTAssertEqual(nonZeroRawResultForZeroUnit[1].finalAmount, 0, accuracy: 0.0001)
+        XCTAssertEqual(nonZeroRawResultForZeroUnit[1].appliedFXFee, 0.02, accuracy: 0.0001)
     }
 
     func testSameCurrencyLastResultRoundTripsCalculationValues() throws {

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -25,6 +25,28 @@ enum LegacyContextMenuFXFeePolicy {
     }
 }
 
+struct LegacyContextMenuCalculation: Equatable {
+    let finalAmount: Float32
+    let appliedFXFee: Float32
+    let ratio: Float32
+
+    static func calculate(
+        rawResult: Float32,
+        unit: Float32,
+        sourceCurrency: String,
+        targetCurrency: String,
+        feeIndex: Int
+    ) -> LegacyContextMenuCalculation {
+        let sameCurrency = sourceCurrency == targetCurrency
+        let appliedFXFee = sameCurrency ? 0 : LegacyContextMenuFXFeePolicy.rate(for: feeIndex)
+        return LegacyContextMenuCalculation(
+            finalAmount: sameCurrency ? unit : rawResult * (1 + appliedFXFee),
+            appliedFXFee: appliedFXFee,
+            ratio: sameCurrency ? 1 : rawResult / unit
+        )
+    }
+}
+
 enum LegacyConvertHistoryCalculations {
     static func toAmount(fromAmount: Float, ratio: Float) -> Float { fromAmount * ratio }
     static func fxFee(toAmount: Float, fxFeeRate: Float) -> Float { toAmount * fxFeeRate }


### PR DESCRIPTION
## Summary
- apply zero FX fee and exact ratio 1 to same-currency context-menu conversions
- preserve cross-currency fee behavior through a shared pure calculation seam
- cover fee selections, LastResult persistence, and cross-currency regression behavior

## Verification
- baseline origin/master: 14/0
- focused RED: same-currency 1.5%/2% retained fees
- focused GREEN: 5/0
- full CurrencyConverterTests: 17/0
- clean app and extension builds: passed

Closes CCS-30