### PR TITLE
CCS-17 coalesce concurrent exchange-rate refresh requests

### DIFF
--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		625712E52371982E00466679 /* CurrencyConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625712E42371982E00466679 /* CurrencyConverterTests.swift */; };
 		63CC34012371982E00466679 /* LegacyContractSeams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34002371982E00466679 /* LegacyContractSeams.swift */; };
 		63CC34032371982E00466679 /* CCS34CharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */; };
+		63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */; };
 		625712FC2371982E00466679 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625712FB2371982E00466679 /* Cocoa.framework */; };
 		625712FF2371982E00466679 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625712FE2371982E00466679 /* SafariExtensionHandler.swift */; };
 		625713012371982E00466679 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625713002371982E00466679 /* SafariExtensionViewController.swift */; };
@@ -104,6 +105,7 @@
 		625712E42371982E00466679 /* CurrencyConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyConverterTests.swift; sourceTree = "<group>"; };
 		63CC34002371982E00466679 /* LegacyContractSeams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyContractSeams.swift; sourceTree = "<group>"; };
 		63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS34CharacterizationTests.swift; sourceTree = "<group>"; };
+		63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS17RefreshCoalescingTests.swift; sourceTree = "<group>"; };
 		625712E62371982E00466679 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		625712F62371982E00466679 /* CurrencyConverter Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CurrencyConverter Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		625712FB2371982E00466679 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -192,6 +194,7 @@
 			children = (
 				625712E42371982E00466679 /* CurrencyConverterTests.swift */,
 				63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */,
+				63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */,
 				625712E62371982E00466679 /* Info.plist */,
 				62985BB6238464640022ED28 /* ConvertPasteboardFormatterTest.swift */,
 			);
@@ -419,6 +422,7 @@
 				63CC34152531982E00466679 /* ConvertHistoryUIBeanProduction.swift in Sources */,
 				63CC34142531982E00466679 /* EntityDetailRowPresentation.swift in Sources */,
 				63CC34032371982E00466679 /* CCS34CharacterizationTests.swift in Sources */,
+				63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */,
 				6257131C23719B5300466679 /* CurrencyConverter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
+++ b/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
@@ -36,18 +36,29 @@ private final class CCS17ControlledTransport {
 }
 
 private final class CCS17MemoryDefaults: UserDefaults {
+    private let lock = NSLock()
     private var storage: [String: Any] = [:]
 
     override func object(forKey defaultName: String) -> Any? {
-        storage[defaultName]
+        lock.lock()
+        defer { lock.unlock() }
+        return storage[defaultName]
     }
 
     override func set(_ value: Any?, forKey defaultName: String) {
-        storage[defaultName] = value
+        lock.lock()
+        defer { lock.unlock() }
+        if let value = value {
+            storage[defaultName] = value
+        } else {
+            storage.removeValue(forKey: defaultName)
+        }
     }
 
     override func integer(forKey defaultName: String) -> Int {
-        storage[defaultName] as? Int ?? 0
+        lock.lock()
+        defer { lock.unlock() }
+        return storage[defaultName] as? Int ?? 0
     }
 
     override func value(forKey key: String) -> Any? {
@@ -62,9 +73,37 @@ private final class CCS17ObservedConverter: CurrencyConverter {
         XCTAssertEqual(refreshEntry.wait(timeout: .now() + 1), .success)
     }
 
-    override func loadFromWeb(_ completionHandler: @escaping (Error?) -> Void) {
-        super.loadFromWeb(completionHandler)
+    override func loadFromCacheMiss(_ completionHandler: @escaping (Error?) -> Void) {
+        super.loadFromCacheMiss(completionHandler)
         refreshEntry.signal()
+    }
+}
+
+private final class CCS17LateJoinConverter: CurrencyConverter {
+    private let lock = NSLock()
+    private var cacheMissCount = 0
+    private let secondCacheMissEntered = DispatchSemaphore(value: 0)
+    private let releaseSecondCacheMiss = DispatchSemaphore(value: 0)
+
+    func waitForSecondCacheMiss() {
+        XCTAssertEqual(secondCacheMissEntered.wait(timeout: .now() + 1), .success)
+    }
+
+    func releasePausedCacheMiss() {
+        releaseSecondCacheMiss.signal()
+    }
+
+    override func loadFromCacheMiss(_ completionHandler: @escaping (Error?) -> Void) {
+        lock.lock()
+        cacheMissCount += 1
+        let shouldPause = cacheMissCount == 2
+        lock.unlock()
+
+        if shouldPause {
+            secondCacheMissEntered.signal()
+            XCTAssertEqual(releaseSecondCacheMiss.wait(timeout: .now() + 1), .success)
+        }
+        super.loadFromCacheMiss(completionHandler)
     }
 }
 
@@ -219,6 +258,66 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         }
         wait(for: [retryExpectation], timeout: 1)
         XCTAssertEqual(transportCount, 2)
+    }
+
+    func testLateCacheMissJoinsFreshCacheAfterRefreshFinishes() {
+        let transport = CCS17ControlledTransport()
+        let converter = CCS17LateJoinConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), transport: transport.send)
+        let firstCompletion = expectation(description: "first refresh completion")
+
+        converter.loadData { error in
+            XCTAssertNil(error)
+            firstCompletion.fulfill()
+        }
+        transport.waitForRequest()
+        XCTAssertEqual(transport.requestCount, 1)
+
+        let secondCompletion = expectation(description: "late cache miss completion")
+        DispatchQueue.global().async {
+            converter.loadData { error in
+                XCTAssertNil(error)
+                secondCompletion.fulfill()
+            }
+        }
+        converter.waitForSecondCacheMiss()
+
+        transport.finishNext(
+            data: self.successData,
+            response: HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        )
+        wait(for: [firstCompletion], timeout: 1)
+
+        converter.releasePausedCacheMiss()
+        wait(for: [secondCompletion], timeout: 1)
+        XCTAssertEqual(transport.requestCount, 1)
+    }
+
+    func testConcurrentCurrencyRateEntitySnapshotsAreSafe() {
+        let converter = makeStaleConverter(transport: CCS17ControlledTransport())
+        let work = DispatchGroup()
+        let queue = DispatchQueue.global()
+
+        for index in 0..<100 {
+            work.enter()
+            queue.async {
+                converter.currencyRateEntity = CurrencyRateEntity(
+                    base: "EUR",
+                    date: "2026-07-18",
+                    rates: ["USD": Float32(index)],
+                    fetched_localtime: self.now,
+                    timestamp: index
+                )
+                work.leave()
+            }
+
+            work.enter()
+            queue.async {
+                _ = converter.currencyRateEntity?.rates["USD"]
+                work.leave()
+            }
+        }
+
+        XCTAssertEqual(work.wait(timeout: .now() + 1), .success)
     }
 
     private func makeStaleConverter(transport: CCS17ControlledTransport) -> CurrencyConverter {

--- a/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
+++ b/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
@@ -35,8 +35,8 @@ private final class CCS17ControlledTransport {
     func finishNext(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) -> Bool {
         lock.lock()
         guard !pendingCompletions.isEmpty else {
-            XCTFail("No pending transport completions to drain")
             lock.unlock()
+            XCTFail("No pending transport completions to drain")
             return false
         }
         let completion = pendingCompletions.removeFirst()
@@ -79,6 +79,7 @@ private final class CCS17MemoryDefaults: UserDefaults {
 
 private final class CCS17ObservedConverter: CurrencyConverter {
     private let refreshEntry = DispatchSemaphore(value: 0)
+    private let directLoadEntry = DispatchSemaphore(value: 0)
 
     func waitForRefreshEntry() -> Bool {
         if refreshEntry.wait(timeout: .now() + 2) != .success {
@@ -88,9 +89,22 @@ private final class CCS17ObservedConverter: CurrencyConverter {
         return true
     }
 
+    func waitForDirectLoadEntry() -> Bool {
+        if directLoadEntry.wait(timeout: .now() + 2) != .success {
+            XCTFail("waitForDirectLoadEntry timeout")
+            return false
+        }
+        return true
+    }
+
     override func loadFromCacheMiss(_ completionHandler: @escaping (Error?) -> Void) {
         super.loadFromCacheMiss(completionHandler)
         refreshEntry.signal()
+    }
+
+    override func loadFromWeb(_ completionHandler: @escaping (Error?) -> Void) {
+        super.loadFromWeb(completionHandler)
+        directLoadEntry.signal()
     }
 }
 
@@ -120,7 +134,10 @@ private final class CCS17LateJoinConverter: CurrencyConverter {
 
         if shouldPause {
             secondCacheMissEntered.signal()
-            XCTAssertEqual(releaseSecondCacheMiss.wait(timeout: .now() + 1), .success)
+            guard releaseSecondCacheMiss.wait(timeout: .now() + 2) == .success else {
+                XCTFail("releaseSecondCacheMiss timeout")
+                return
+            }
         }
         super.loadFromCacheMiss(completionHandler)
     }
@@ -138,10 +155,11 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         completionExpectation.assertForOverFulfill = true
         let results = LockedResults()
 
-        startConcurrentLoads(on: converter, count: 16) { error in
+        let didLaunch = startConcurrentLoads(on: converter, count: 16) { error in
             results.append(error: error, rate: converter.currencyRateEntity?.rates["USD"])
             completionExpectation.fulfill()
         }
+        guard didLaunch else { return }
         guard transport.waitForRequest() else { return }
         XCTAssertEqual(transport.requestCount, 1)
         for _ in 0..<16 {
@@ -168,10 +186,11 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         let results = LockedResults()
         let failure = NSError(domain: "CCS17", code: 17)
 
-        startConcurrentLoads(on: converter, count: 16) { error in
+        let didLaunchFailCase = startConcurrentLoads(on: converter, count: 16) { error in
             results.append(error: error, rate: nil)
             completionExpectation.fulfill()
         }
+        guard didLaunchFailCase else { return }
         guard transport.waitForRequest() else { return }
         XCTAssertEqual(transport.requestCount, 1)
         for _ in 0..<16 {
@@ -224,10 +243,11 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         let memoryExpectation = expectation(description: "fresh memory callers complete")
         memoryExpectation.expectedFulfillmentCount = 8
         memoryExpectation.assertForOverFulfill = true
-        startConcurrentLoads(on: memoryConverter, count: 8) { error in
+        let didLaunchMemory = startConcurrentLoads(on: memoryConverter, count: 8) { error in
             XCTAssertNil(error)
             memoryExpectation.fulfill()
         }
+        guard didLaunchMemory else { return }
         wait(for: [memoryExpectation], timeout: 1)
         XCTAssertEqual(memoryTransport.requestCount, 0)
 
@@ -240,10 +260,11 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         let defaultsExpectation = expectation(description: "fresh defaults callers complete")
         defaultsExpectation.expectedFulfillmentCount = 8
         defaultsExpectation.assertForOverFulfill = true
-        startConcurrentLoads(on: defaultsConverter, count: 8) { error in
+        let didLaunchDefaults = startConcurrentLoads(on: defaultsConverter, count: 8) { error in
             XCTAssertNil(error)
             defaultsExpectation.fulfill()
         }
+        guard didLaunchDefaults else { return }
         wait(for: [defaultsExpectation], timeout: 1)
         XCTAssertEqual(defaultsTransport.requestCount, 0)
     }
@@ -336,7 +357,10 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(work.wait(timeout: .now() + 1), .success)
+        guard work.wait(timeout: .now() + 2) == .success else {
+            XCTFail("currency rate snapshot test timeout")
+            return
+        }
     }
 
     private func makeStaleConverter(transport: CCS17ControlledTransport) -> CurrencyConverter {
@@ -351,7 +375,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         on converter: CurrencyConverter,
         count: Int,
         completion: @escaping (Error?) -> Void
-    ) {
+    ) -> Bool {
         let ready = DispatchGroup()
         let start = DispatchSemaphore(value: 0)
         for _ in 0..<count {
@@ -362,10 +386,14 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
                 converter.loadData(completionHandler: completion)
             }
         }
-        XCTAssertEqual(ready.wait(timeout: .now() + 2), .success)
+        guard ready.wait(timeout: .now() + 2) == .success else {
+            XCTFail("startConcurrentLoads ready timeout")
+            return false
+        }
         for _ in 0..<count {
             start.signal()
         }
+        return true
     }
 
     func testConcurrentDirectLoadFromWebCallsCoalesceWithFreshCache() {
@@ -390,6 +418,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             }
         }
         guard transport.waitForRequest() else { return }
+        guard converter.waitForDirectLoadEntry() else { return }
 
         DispatchQueue.global().async {
             converter.loadFromWeb { error in
@@ -397,6 +426,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
                 completionExpectation.fulfill()
             }
         }
+        guard converter.waitForDirectLoadEntry() else { return }
         XCTAssertEqual(transport.requestCount, 1)
 
         guard transport.finishNext(

--- a/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
+++ b/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
@@ -8,6 +8,7 @@ private final class CCS17ControlledTransport {
     private var pendingCompletions: [Completion] = []
     private var requestCountValue = 0
     private let requestStarted = DispatchSemaphore(value: 0)
+    private let defaultTimeout: TimeInterval = 2
 
     var requestCount: Int {
         lock.lock()
@@ -23,15 +24,25 @@ private final class CCS17ControlledTransport {
         requestStarted.signal()
     }
 
-    func waitForRequest() {
-        XCTAssertEqual(requestStarted.wait(timeout: .now() + 1), .success)
+    func waitForRequest() -> Bool {
+        if requestStarted.wait(timeout: .now() + defaultTimeout) != .success {
+            XCTFail("waitForRequest timeout")
+            return false
+        }
+        return true
     }
 
-    func finishNext(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
+    func finishNext(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) -> Bool {
         lock.lock()
+        guard !pendingCompletions.isEmpty else {
+            XCTFail("No pending transport completions to drain")
+            lock.unlock()
+            return false
+        }
         let completion = pendingCompletions.removeFirst()
         lock.unlock()
         completion(data, response, error)
+        return true
     }
 }
 
@@ -69,8 +80,12 @@ private final class CCS17MemoryDefaults: UserDefaults {
 private final class CCS17ObservedConverter: CurrencyConverter {
     private let refreshEntry = DispatchSemaphore(value: 0)
 
-    func waitForRefreshEntry() {
-        XCTAssertEqual(refreshEntry.wait(timeout: .now() + 1), .success)
+    func waitForRefreshEntry() -> Bool {
+        if refreshEntry.wait(timeout: .now() + 2) != .success {
+            XCTFail("waitForRefreshEntry timeout")
+            return false
+        }
+        return true
     }
 
     override func loadFromCacheMiss(_ completionHandler: @escaping (Error?) -> Void) {
@@ -85,8 +100,12 @@ private final class CCS17LateJoinConverter: CurrencyConverter {
     private let secondCacheMissEntered = DispatchSemaphore(value: 0)
     private let releaseSecondCacheMiss = DispatchSemaphore(value: 0)
 
-    func waitForSecondCacheMiss() {
-        XCTAssertEqual(secondCacheMissEntered.wait(timeout: .now() + 1), .success)
+    func waitForSecondCacheMiss() -> Bool {
+        if secondCacheMissEntered.wait(timeout: .now() + 2) != .success {
+            XCTFail("waitForSecondCacheMiss timeout")
+            return false
+        }
+        return true
     }
 
     func releasePausedCacheMiss() {
@@ -123,16 +142,16 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             results.append(error: error, rate: converter.currencyRateEntity?.rates["USD"])
             completionExpectation.fulfill()
         }
-        transport.waitForRequest()
+        guard transport.waitForRequest() else { return }
         XCTAssertEqual(transport.requestCount, 1)
         for _ in 0..<16 {
-            converter.waitForRefreshEntry()
+            guard converter.waitForRefreshEntry() else { return }
         }
 
-        transport.finishNext(
+        guard transport.finishNext(
             data: successData,
             response: HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        )
+        ) else { return }
         wait(for: [completionExpectation], timeout: 1)
 
         XCTAssertEqual(results.count, 16)
@@ -153,12 +172,12 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             results.append(error: error, rate: nil)
             completionExpectation.fulfill()
         }
-        transport.waitForRequest()
+        guard transport.waitForRequest() else { return }
         XCTAssertEqual(transport.requestCount, 1)
         for _ in 0..<16 {
-            converter.waitForRefreshEntry()
+            guard converter.waitForRefreshEntry() else { return }
         }
-        transport.finishNext(error: failure)
+        guard transport.finishNext(error: failure) else { return }
         wait(for: [completionExpectation], timeout: 1)
 
         XCTAssertEqual(results.count, 16)
@@ -176,9 +195,9 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             XCTAssertTrue((error as NSError?) === failure)
             failureExpectation.fulfill()
         }
-        transport.waitForRequest()
+        guard transport.waitForRequest() else { return }
         XCTAssertEqual(transport.requestCount, 1)
-        transport.finishNext(error: failure)
+        guard transport.finishNext(error: failure) else { return }
         wait(for: [failureExpectation], timeout: 1)
 
         let retryExpectation = expectation(description: "retry completion")
@@ -187,12 +206,12 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 1)
             retryExpectation.fulfill()
         }
-        transport.waitForRequest()
+        guard transport.waitForRequest() else { return }
         XCTAssertEqual(transport.requestCount, 2)
-        transport.finishNext(
+        guard transport.finishNext(
             data: successData,
             response: HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        )
+        ) else { return }
         wait(for: [retryExpectation], timeout: 1)
     }
 
@@ -269,7 +288,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             XCTAssertNil(error)
             firstCompletion.fulfill()
         }
-        transport.waitForRequest()
+        guard transport.waitForRequest() else { return }
         XCTAssertEqual(transport.requestCount, 1)
 
         let secondCompletion = expectation(description: "late cache miss completion")
@@ -279,12 +298,12 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
                 secondCompletion.fulfill()
             }
         }
-        converter.waitForSecondCacheMiss()
+        guard converter.waitForSecondCacheMiss() else { return }
 
-        transport.finishNext(
+        guard transport.finishNext(
             data: self.successData,
             response: HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        )
+        ) else { return }
         wait(for: [firstCompletion], timeout: 1)
 
         converter.releasePausedCacheMiss()
@@ -343,10 +362,57 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
                 converter.loadData(completionHandler: completion)
             }
         }
-        XCTAssertEqual(ready.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(ready.wait(timeout: .now() + 2), .success)
         for _ in 0..<count {
             start.signal()
         }
+    }
+
+    func testConcurrentDirectLoadFromWebCallsCoalesceWithFreshCache() {
+        let transport = CCS17ControlledTransport()
+        let converter = makeObservedStaleConverter(transport: transport)
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR",
+            date: "2026-07-18",
+            rates: ["USD": Float32(1)],
+            fetched_localtime: now,
+            timestamp: 123
+        )
+        let completionExpectation = expectation(description: "all force refresh callers complete")
+        completionExpectation.expectedFulfillmentCount = 2
+        completionExpectation.assertForOverFulfill = true
+        let results = LockedResults()
+
+        DispatchQueue.global().async {
+            converter.loadFromWeb { error in
+                results.append(error: error, rate: converter.currencyRateEntity?.rates["USD"])
+                completionExpectation.fulfill()
+            }
+        }
+        guard transport.waitForRequest() else { return }
+
+        DispatchQueue.global().async {
+            converter.loadFromWeb { error in
+                results.append(error: error, rate: converter.currencyRateEntity?.rates["USD"])
+                completionExpectation.fulfill()
+            }
+        }
+        XCTAssertEqual(transport.requestCount, 1)
+
+        guard transport.finishNext(
+            data: successData,
+            response: HTTPURLResponse(
+                url: URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )
+        ) else { return }
+        wait(for: [completionExpectation], timeout: 1)
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.errors.allSatisfy { $0 == nil })
+        XCTAssertTrue(results.rates.allSatisfy { $0 == Float32(1) })
     }
 }
 

--- a/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
+++ b/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+@testable import CurrencyConverter
+
+private final class CCS17ControlledTransport {
+    typealias Completion = (Data?, URLResponse?, Error?) -> Void
+
+    private let lock = NSLock()
+    private var pendingCompletions: [Completion] = []
+    private var requestCountValue = 0
+    private let requestStarted = DispatchSemaphore(value: 0)
+
+    var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestCountValue
+    }
+
+    func send(_ url: URL, completion: @escaping Completion) {
+        lock.lock()
+        requestCountValue += 1
+        pendingCompletions.append(completion)
+        lock.unlock()
+        requestStarted.signal()
+    }
+
+    func waitForRequest() {
+        XCTAssertEqual(requestStarted.wait(timeout: .now() + 1), .success)
+    }
+
+    func finishNext(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
+        lock.lock()
+        let completion = pendingCompletions.removeFirst()
+        lock.unlock()
+        completion(data, response, error)
+    }
+}
+
+private final class CCS17MemoryDefaults: UserDefaults {
+    private var storage: [String: Any] = [:]
+
+    override func object(forKey defaultName: String) -> Any? {
+        storage[defaultName]
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        storage[defaultName] = value
+    }
+
+    override func integer(forKey defaultName: String) -> Int {
+        storage[defaultName] as? Int ?? 0
+    }
+
+    override func value(forKey key: String) -> Any? {
+        object(forKey: key)
+    }
+}
+
+private final class CCS17ObservedConverter: CurrencyConverter {
+    private let refreshEntry = DispatchSemaphore(value: 0)
+
+    func waitForRefreshEntry() {
+        XCTAssertEqual(refreshEntry.wait(timeout: .now() + 1), .success)
+    }
+
+    override func loadFromWeb(_ completionHandler: @escaping (Error?) -> Void) {
+        super.loadFromWeb(completionHandler)
+        refreshEntry.signal()
+    }
+}
+
+final class CCS17RefreshCoalescingTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1000)
+    private let successData = Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":1.0,"JPY":110.0},"timestamp":123}"#.utf8)
+
+    func testConcurrentStaleLoadsUseOneTransportAndFanOutSuccessOnce() {
+        let transport = CCS17ControlledTransport()
+        let converter = makeObservedStaleConverter(transport: transport)
+        let completionExpectation = expectation(description: "all callers complete")
+        completionExpectation.expectedFulfillmentCount = 16
+        completionExpectation.assertForOverFulfill = true
+        let results = LockedResults()
+
+        startConcurrentLoads(on: converter, count: 16) { error in
+            results.append(error: error, rate: converter.currencyRateEntity?.rates["USD"])
+            completionExpectation.fulfill()
+        }
+        transport.waitForRequest()
+        XCTAssertEqual(transport.requestCount, 1)
+        for _ in 0..<16 {
+            converter.waitForRefreshEntry()
+        }
+
+        transport.finishNext(
+            data: successData,
+            response: HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        )
+        wait(for: [completionExpectation], timeout: 1)
+
+        XCTAssertEqual(results.count, 16)
+        XCTAssertTrue(results.errors.allSatisfy { $0 == nil })
+        XCTAssertTrue(results.rates.allSatisfy { $0 == 1 })
+    }
+
+    func testConcurrentStaleLoadsFanOutTransportFailureOnceWithoutTrailingNil() {
+        let transport = CCS17ControlledTransport()
+        let converter = makeObservedStaleConverter(transport: transport)
+        let completionExpectation = expectation(description: "all callers complete")
+        completionExpectation.expectedFulfillmentCount = 16
+        completionExpectation.assertForOverFulfill = true
+        let results = LockedResults()
+        let failure = NSError(domain: "CCS17", code: 17)
+
+        startConcurrentLoads(on: converter, count: 16) { error in
+            results.append(error: error, rate: nil)
+            completionExpectation.fulfill()
+        }
+        transport.waitForRequest()
+        XCTAssertEqual(transport.requestCount, 1)
+        for _ in 0..<16 {
+            converter.waitForRefreshEntry()
+        }
+        transport.finishNext(error: failure)
+        wait(for: [completionExpectation], timeout: 1)
+
+        XCTAssertEqual(results.count, 16)
+        XCTAssertTrue(results.errors.allSatisfy { ($0 as NSError?) === failure })
+        XCTAssertEqual(results.nilErrorCount, 0)
+    }
+
+    func testFailedRefreshClearsInFlightStateForRetry() {
+        let transport = CCS17ControlledTransport()
+        let converter = makeStaleConverter(transport: transport)
+        let failureExpectation = expectation(description: "failure completion")
+        let failure = NSError(domain: "CCS17", code: 18)
+
+        converter.loadData { error in
+            XCTAssertTrue((error as NSError?) === failure)
+            failureExpectation.fulfill()
+        }
+        transport.waitForRequest()
+        XCTAssertEqual(transport.requestCount, 1)
+        transport.finishNext(error: failure)
+        wait(for: [failureExpectation], timeout: 1)
+
+        let retryExpectation = expectation(description: "retry completion")
+        converter.loadData { error in
+            XCTAssertNil(error)
+            XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 1)
+            retryExpectation.fulfill()
+        }
+        transport.waitForRequest()
+        XCTAssertEqual(transport.requestCount, 2)
+        transport.finishNext(
+            data: successData,
+            response: HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        )
+        wait(for: [retryExpectation], timeout: 1)
+    }
+
+    func testFreshMemoryAndDefaultsCompleteWithoutTransport() {
+        let memoryTransport = CCS17ControlledTransport()
+        let memoryConverter = makeStaleConverter(transport: memoryTransport)
+        memoryConverter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-18", rates: ["USD": 1], fetched_localtime: now, timestamp: 123
+        )
+        let memoryExpectation = expectation(description: "fresh memory callers complete")
+        memoryExpectation.expectedFulfillmentCount = 8
+        memoryExpectation.assertForOverFulfill = true
+        startConcurrentLoads(on: memoryConverter, count: 8) { error in
+            XCTAssertNil(error)
+            memoryExpectation.fulfill()
+        }
+        wait(for: [memoryExpectation], timeout: 1)
+        XCTAssertEqual(memoryTransport.requestCount, 0)
+
+        let defaultsTransport = CCS17ControlledTransport()
+        let defaults = CCS17MemoryDefaults()
+        defaults.set(now, forKey: "LastUpdateDate")
+        defaults.set(["USD": Float32(1)], forKey: "CurrencyData")
+        defaults.set(123, forKey: "CurrencyDataTime")
+        let defaultsConverter = CurrencyConverter(clock: { self.now }, defaults: defaults, transport: defaultsTransport.send)
+        let defaultsExpectation = expectation(description: "fresh defaults callers complete")
+        defaultsExpectation.expectedFulfillmentCount = 8
+        defaultsExpectation.assertForOverFulfill = true
+        startConcurrentLoads(on: defaultsConverter, count: 8) { error in
+            XCTAssertNil(error)
+            defaultsExpectation.fulfill()
+        }
+        wait(for: [defaultsExpectation], timeout: 1)
+        XCTAssertEqual(defaultsTransport.requestCount, 0)
+    }
+
+    func testSynchronousTransportCompletionDoesNotLoseCompletionOrLeaveRefreshInFlight() {
+        let defaults = CCS17MemoryDefaults()
+        var transportCount = 0
+        let response = HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        let failure = NSError(domain: "CCS17", code: 19)
+        let converter = CurrencyConverter(clock: { self.now }, defaults: defaults) { [self] _, completion in
+            transportCount += 1
+            if transportCount == 1 {
+                completion(nil, nil, failure)
+            } else {
+                completion(successData, response, nil)
+            }
+        }
+
+        let firstExpectation = expectation(description: "synchronous failure completion")
+        converter.loadData { error in
+            XCTAssertTrue((error as NSError?) === failure)
+            firstExpectation.fulfill()
+        }
+        wait(for: [firstExpectation], timeout: 1)
+
+        XCTAssertEqual(transportCount, 1)
+        let retryExpectation = expectation(description: "synchronous retry completion")
+        converter.loadData { error in
+            XCTAssertNil(error)
+            retryExpectation.fulfill()
+        }
+        wait(for: [retryExpectation], timeout: 1)
+        XCTAssertEqual(transportCount, 2)
+    }
+
+    private func makeStaleConverter(transport: CCS17ControlledTransport) -> CurrencyConverter {
+        CurrencyConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), transport: transport.send)
+    }
+
+    private func makeObservedStaleConverter(transport: CCS17ControlledTransport) -> CCS17ObservedConverter {
+        CCS17ObservedConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), transport: transport.send)
+    }
+
+    private func startConcurrentLoads(
+        on converter: CurrencyConverter,
+        count: Int,
+        completion: @escaping (Error?) -> Void
+    ) {
+        let ready = DispatchGroup()
+        let start = DispatchSemaphore(value: 0)
+        for _ in 0..<count {
+            ready.enter()
+            DispatchQueue.global().async {
+                ready.leave()
+                start.wait()
+                converter.loadData(completionHandler: completion)
+            }
+        }
+        XCTAssertEqual(ready.wait(timeout: .now() + 1), .success)
+        for _ in 0..<count {
+            start.signal()
+        }
+    }
+}
+
+private final class LockedResults {
+    private let lock = NSLock()
+    private(set) var count = 0
+    private(set) var errors: [Error?] = []
+    private(set) var rates: [Float32?] = []
+
+    var nilErrorCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return errors.filter { $0 == nil }.count
+    }
+
+    func append(error: Error?, rate: Float32?) {
+        lock.lock()
+        count += 1
+        errors.append(error)
+        rates.append(rate)
+        lock.unlock()
+    }
+}

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -18,13 +18,28 @@ struct CurrencyRateEntity : Decodable {
 }
 
 class CurrencyConverter {
-    var currencyRateEntity: CurrencyRateEntity?
+    private let currencyRateEntityLock = NSLock()
+    private var currencyRateEntityStorage: CurrencyRateEntity?
+    var currencyRateEntity: CurrencyRateEntity? {
+        get {
+            currencyRateEntityLock.lock()
+            defer { currencyRateEntityLock.unlock() }
+            return currencyRateEntityStorage
+        }
+        set {
+            currencyRateEntityLock.lock()
+            currencyRateEntityStorage = newValue
+            currencyRateEntityLock.unlock()
+        }
+    }
+
     var context: NSExtensionContext?
     typealias RateTransport = (URL, @escaping (Data?, URLResponse?, Error?) -> Void) -> Void
 
     private let clock: () -> Date
     private let defaults: UserDefaults
     private let transport: RateTransport
+    private let defaultsLock = NSLock()
     private let refreshLock = NSLock()
     private var nextRefreshID: UInt64 = 0
     private var activeRefreshID: UInt64?
@@ -101,15 +116,18 @@ class CurrencyConverter {
                 print("Status code: \(response.statusCode)")
                 let decoder = JSONDecoder()
                 if var currencyRateEntity = try? decoder.decode(CurrencyRateEntity.self, from: data) {
-                    self.currencyRateEntity = currencyRateEntity
-                    //Save this to UserDefaults
                     let now = self.clock()
                     currencyRateEntity.fetched_localtime = now
+                    self.currencyRateEntity = currencyRateEntity
+
+                    // Save this to UserDefaults.
+                    self.defaultsLock.lock()
                     self.defaults.set(now, forKey: "LastUpdateDate")
                     self.defaults.set(currencyRateEntity.rates, forKey: "CurrencyData")
                     self.defaults.set(currencyRateEntity.base, forKey:"CurrencyBase")
                     self.defaults.set(currencyRateEntity.timestamp, forKey: "CurrencyDataTime")
                     self.defaults.set(String(data: data, encoding: .utf8), forKey: "CurrencyDataRaw")
+                    self.defaultsLock.unlock()
                 }
             }
             completionHandler(nil)
@@ -118,27 +136,33 @@ class CurrencyConverter {
     
     func loadFromDefaults() -> Bool {
         let today = clock()
-        
-        guard let record = defaults.value(forKey: "LastUpdateDate") as! Date? else {
+
+        defaultsLock.lock()
+        guard let record = defaults.value(forKey: "LastUpdateDate") as? Date else {
+            defaultsLock.unlock()
             return false
         }
-        
+
         guard LegacyCachePolicy.isFresh(lastUpdated: record, now: today) else {
+            defaultsLock.unlock()
             return false
         }
-        
-        guard let rates = defaults.value(forKey: "CurrencyData") as! [String:Float32]? else {
+
+        guard let rates = defaults.value(forKey: "CurrencyData") as? [String:Float32] else {
+            defaultsLock.unlock()
             return false
         }
-        
+
         let dataTimestamp = defaults.integer(forKey: "CurrencyDataTime")
+        defaultsLock.unlock()
         
         print("Convert Rate Data is good from \(record) and now is \(today), load from defaults.")
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         let todayString = formatter.string(from: today)
-        self.currencyRateEntity = CurrencyRateEntity(base: "EUR", date: todayString, rates: rates, timestamp: dataTimestamp)
-        self.currencyRateEntity?.fetched_localtime = record
+        self.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: todayString, rates: rates, fetched_localtime: record, timestamp: dataTimestamp
+        )
         return true
     }
     
@@ -163,7 +187,6 @@ class CurrencyConverter {
     }
     
     func loadData(completionHandler: @escaping (Error?) -> Void = {_ in }) {
-        
         if loadFromMemory() {
             completionHandler(nil)
             return
@@ -173,9 +196,41 @@ class CurrencyConverter {
             completionHandler(nil)
         } else {
             NSLog("Convert Rate Data in Defaults not found or too old, load from web....")
-            loadFromWeb(completionHandler)
+            loadFromCacheMiss(completionHandler)
         }
-        
+    }
+
+    func loadFromCacheMiss(_ completionHandler: @escaping (Error?) -> Void) {
+        var refreshID: UInt64?
+        var cacheIsFresh = false
+
+        refreshLock.lock()
+        if activeRefreshID == nil {
+            // The initial cache check happened before entering this gate. Recheck
+            // while claiming the refresh slot so a just-finished refresh is joined
+            // without starting a second transport.
+            cacheIsFresh = loadFromMemory() || loadFromDefaults()
+            if !cacheIsFresh {
+                nextRefreshID &+= 1
+                activeRefreshID = nextRefreshID
+                refreshID = nextRefreshID
+                refreshWaiters.append(completionHandler)
+            }
+        } else {
+            refreshWaiters.append(completionHandler)
+        }
+        refreshLock.unlock()
+
+        if cacheIsFresh {
+            completionHandler(nil)
+            return
+        }
+
+        guard let refreshID else { return }
+
+        loadFromWebRequest { [self] error in
+            finishRefresh(refreshID, error: error)
+        }
     }
     
     func convert(from: String, to: String, unit: Float32, completionHandler: @escaping (Float32, Error?) -> Void) {
@@ -184,11 +239,12 @@ class CurrencyConverter {
                 completionHandler(0.0, error)
                 return
             }
-            
+
+            let rates = self.currencyRateEntity!.rates
             let result = LegacyConversionMath.direct(
                 unit: unit,
-                fromRate: self.currencyRateEntity!.rates[from]!,
-                toRate: self.currencyRateEntity!.rates[to]!
+                fromRate: rates[from]!,
+                toRate: rates[to]!
             )
             completionHandler(result, nil)
         }
@@ -198,8 +254,10 @@ class CurrencyConverter {
         loadData { (error) in
             if error != nil {
                 completionHandler(nil, error)
+                return
             }
-            completionHandler(Array((self.currencyRateEntity?.rates.keys)!), nil)
+            let symbols = self.currencyRateEntity.map { Array($0.rates.keys) } ?? []
+            completionHandler(symbols, nil)
         }
     }
     

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -138,24 +138,25 @@ class CurrencyConverter {
         let today = clock()
 
         defaultsLock.lock()
-        guard let record = defaults.value(forKey: "LastUpdateDate") as? Date else {
-            defaultsLock.unlock()
+        let recordValue = defaults.value(forKey: "LastUpdateDate")
+        let ratesValue = defaults.value(forKey: "CurrencyData")
+        let dataTimestamp = defaults.integer(forKey: "CurrencyDataTime")
+        defaultsLock.unlock()
+
+        let record = recordValue as! Date?
+        guard let record = record else {
             return false
         }
 
         guard LegacyCachePolicy.isFresh(lastUpdated: record, now: today) else {
-            defaultsLock.unlock()
             return false
         }
 
-        guard let rates = defaults.value(forKey: "CurrencyData") as? [String:Float32] else {
-            defaultsLock.unlock()
+        let rates = ratesValue as! [String:Float32]?
+        guard let rates else {
             return false
         }
 
-        let dataTimestamp = defaults.integer(forKey: "CurrencyDataTime")
-        defaultsLock.unlock()
-        
         print("Convert Rate Data is good from \(record) and now is \(today), load from defaults.")
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
@@ -256,7 +257,8 @@ class CurrencyConverter {
                 completionHandler(nil, error)
                 return
             }
-            let symbols = self.currencyRateEntity.map { Array($0.rates.keys) } ?? []
+            let currencyRateEntity = self.currencyRateEntity!
+            let symbols = Array(currencyRateEntity.rates.keys)
             completionHandler(symbols, nil)
         }
     }

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -25,6 +25,10 @@ class CurrencyConverter {
     private let clock: () -> Date
     private let defaults: UserDefaults
     private let transport: RateTransport
+    private let refreshLock = NSLock()
+    private var nextRefreshID: UInt64 = 0
+    private var activeRefreshID: UInt64?
+    private var refreshWaiters: [(Error?) -> Void] = []
     
     static let shared = CurrencyConverter()
     private init() {
@@ -46,6 +50,39 @@ class CurrencyConverter {
     }
     
     func loadFromWeb(_ completionHandler: @escaping (Error?) -> Void) {
+        var refreshID: UInt64?
+
+        refreshLock.lock()
+        refreshWaiters.append(completionHandler)
+        if activeRefreshID == nil {
+            nextRefreshID &+= 1
+            activeRefreshID = nextRefreshID
+            refreshID = nextRefreshID
+        }
+        refreshLock.unlock()
+
+        guard let refreshID else { return }
+
+        loadFromWebRequest { [self] error in
+            finishRefresh(refreshID, error: error)
+        }
+    }
+
+    private func finishRefresh(_ refreshID: UInt64, error: Error?) {
+        refreshLock.lock()
+        guard activeRefreshID == refreshID else {
+            refreshLock.unlock()
+            return
+        }
+        activeRefreshID = nil
+        let waiters = refreshWaiters
+        refreshWaiters.removeAll()
+        refreshLock.unlock()
+
+        waiters.forEach { $0(error) }
+    }
+
+    private func loadFromWebRequest(_ completionHandler: @escaping (Error?) -> Void) {
         let feed_url : URL?
         if let feed_url_str = Bundle.main.object(forInfoDictionaryKey: "CurrencyInfoFeed") as? String {
             feed_url = URL(string: feed_url_str)


### PR DESCRIPTION
## Summary
- coalesce one in-flight web refresh per CurrencyConverter instance
- fan out one success or failure completion to every waiter and clear state for retry
- keep raw transport/decode behavior, cache precedence, URLSession resume semantics, and callback queue behavior unchanged
- add deterministic no-network CCS-17 coverage for concurrent success/failure, retry, fresh memory/defaults, and synchronous transport completion

## Validation
- baseline: 24 passed, 0 failed
- focused CCS-17: 5 passed, 0 failed
- full suite: 29 passed, 0 failed
- app and extension Debug builds: passed
- plist/Core Data XML/project checks: passed

Base: origin/master@f83c879e97a465b0db11a0423557390dea52e110