### PR TITLE
CCS-10 surface rate-feed failures and use last-known-good data

### DIFF
--- a/CurrencyConverter Extension/Base.lproj/SafariExtensionViewController.xib
+++ b/CurrencyConverter Extension/Base.lproj/SafariExtensionViewController.xib
@@ -30,7 +30,7 @@
                     <rect key="frame" x="10" y="15" width="310" height="120"/>
                     <subviews>
                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kRc-jp-qL9">
-                            <rect key="frame" x="0.0" y="91" width="405" height="21"/>
+                            <rect key="frame" x="0.0" y="91" width="310" height="21"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Eb-xW-tdx">
                                     <rect key="frame" x="-2" y="3" width="53" height="16"/>
@@ -136,10 +136,10 @@
                             </customSpacing>
                         </stackView>
                         <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gaL-NW-C6N">
-                            <rect key="frame" x="0.0" y="39" width="347" height="42"/>
+                            <rect key="frame" x="0.0" y="39" width="310" height="42"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gvL-DV-pOX">
-                                    <rect key="frame" x="-2" y="26" width="351" height="16"/>
+                                    <rect key="frame" x="-2" y="26" width="310" height="16"/>
                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Credit Card Foreigen Transaction Fee" id="xM6-Ua-JWT">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -147,7 +147,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="15" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uZA-NJ-7VH">
-                                    <rect key="frame" x="0.0" y="0.0" width="347" height="16"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="310" height="16"/>
                                     <subviews>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hWV-e4-dzb">
                                             <rect key="frame" x="-1" y="-1" width="41" height="18"/>
@@ -205,7 +205,7 @@
                             </customSpacing>
                         </stackView>
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Uuk-Yp-v7x">
-                            <rect key="frame" x="0.0" y="0.0" width="211" height="29"/>
+                            <rect key="frame" x="0.0" y="0.0" width="310" height="29"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZQ6-Cb-hfO">
                                     <rect key="frame" x="-2" y="13" width="85" height="16"/>

--- a/CurrencyConverter Extension/Base.lproj/SafariExtensionViewController.xib
+++ b/CurrencyConverter Extension/Base.lproj/SafariExtensionViewController.xib
@@ -23,11 +23,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="425" height="142"/>
+            <rect key="frame" x="0.0" y="0.0" width="330" height="150"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fGs-PP-re3">
-                    <rect key="frame" x="10" y="15" width="405" height="112"/>
+                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fGs-PP-re3">
+                    <rect key="frame" x="10" y="15" width="310" height="120"/>
                     <subviews>
                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kRc-jp-qL9">
                             <rect key="frame" x="0.0" y="91" width="405" height="21"/>
@@ -249,7 +249,11 @@
                             </customSpacing>
                         </stackView>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cCS10-status">
-                            <rect key="frame" x="0.0" y="-29" width="405" height="16"/>
+                            <rect key="frame" x="0.0" y="0.0" width="310" height="16"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="310" id="CCS10-status-width"/>
+                                <constraint firstAttribute="height" constant="16" id="CCS10-status-height"/>
+                            </constraints>
                             <textFieldCell key="cell" lineBreakMode="truncatingTail" title="Exchange rates are current." id="cCS10-status-cell">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>

--- a/CurrencyConverter Extension/Base.lproj/SafariExtensionViewController.xib
+++ b/CurrencyConverter Extension/Base.lproj/SafariExtensionViewController.xib
@@ -16,6 +16,7 @@
                 <outlet property="fxRateBtn15" destination="ReV-OI-vOn" id="bTW-U9-KbT"/>
                 <outlet property="fxRateBtn2" destination="PKi-Ew-R7f" id="yJc-NF-mvb"/>
                 <outlet property="ratesText" destination="TyX-ll-gIp" id="NaC-aQ-Wbu"/>
+                <outlet property="statusText" destination="cCS10-status" id="CCS10-status-outlet"/>
                 <outlet property="view" destination="c22-O7-iKe" id="vwT-Xx-Aiz"/>
             </connections>
         </customObject>
@@ -247,6 +248,14 @@
                                 <real value="3.4028234663852886e+38"/>
                             </customSpacing>
                         </stackView>
+                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cCS10-status">
+                            <rect key="frame" x="0.0" y="-29" width="405" height="16"/>
+                            <textFieldCell key="cell" lineBreakMode="truncatingTail" title="Exchange rates are current." id="cCS10-status-cell">
+                                <font key="font" metaFont="smallSystem"/>
+                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
                     </subviews>
                     <visibilityPriorities>
                         <integer value="1000"/>

--- a/CurrencyConverter Extension/SafariExtensionHandler.swift
+++ b/CurrencyConverter Extension/SafariExtensionHandler.swift
@@ -64,7 +64,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                     let formatter = ConvertPasteboardFormatter.init(fromSymbol: convertFromSym, fromAmount: unit, toSymbol: convertToSym, toAmount: price)
                     let formattingIndex = sharedUserDefaults.value(forKey: "FormatIndex") as? Int ?? 0
                     let lastCurrencyExchangeStr = formatter.getFormattedString(formatIndex: formattingIndex)
-                    validationHandler(false, lastCurrencyExchangeStr)
+                    validationHandler(false, LegacyContextMenuPresentation.menuTitle(resultString: lastCurrencyExchangeStr, status: CurrencyConverter.shared.rateDataStatus))
                     let lastResult = LastResult(resultString: lastCurrencyExchangeStr, convertFrom: convertFromSym, convertTo: convertToSym, units: unit, fxRate: calculation.appliedFXFee, ratio: calculation.ratio)
                     sharedUserDefaults.set(try? LastResultPersistence.encode(lastResult), forKey: "lastResult")
                     

--- a/CurrencyConverter Extension/SafariExtensionHandler.swift
+++ b/CurrencyConverter Extension/SafariExtensionHandler.swift
@@ -64,9 +64,10 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                     let formatter = ConvertPasteboardFormatter.init(fromSymbol: convertFromSym, fromAmount: unit, toSymbol: convertToSym, toAmount: price)
                     let formattingIndex = sharedUserDefaults.value(forKey: "FormatIndex") as? Int ?? 0
                     let lastCurrencyExchangeStr = formatter.getFormattedString(formatIndex: formattingIndex)
-                    validationHandler(false, LegacyContextMenuPresentation.menuTitle(resultString: lastCurrencyExchangeStr, status: status))
                     let lastResult = LastResult(resultString: lastCurrencyExchangeStr, convertFrom: convertFromSym, convertTo: convertToSym, units: unit, fxRate: calculation.appliedFXFee, ratio: calculation.ratio)
                     sharedUserDefaults.set(try? LastResultPersistence.encode(lastResult), forKey: "lastResult")
+                    let title = LegacyContextMenuPresentation.menuTitle(resultString: lastCurrencyExchangeStr, status: status)
+                    validationHandler(false, title)
                     
                 }
             } else {

--- a/CurrencyConverter Extension/SafariExtensionHandler.swift
+++ b/CurrencyConverter Extension/SafariExtensionHandler.swift
@@ -12,8 +12,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     
     override func messageReceived(withName messageName: String, from page: SFSafariPage, userInfo: [String : Any]?) {
         if messageName == "CCInitialize" {
-            CurrencyConverter.shared.loadData { (Error) in
-                print("CurrencyConverter Initialized")
+            CurrencyConverter.shared.loadData { _ in
             }
         }
     }
@@ -41,14 +40,18 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
             formatter.numberStyle = .decimal
             if let selected = formatter.number(from: userInfo?["selected"] as? String ?? "") {
                 
-                let convertFromSym = sharedUserDefaults.value(forKey: "convertFromSym") as! String? ?? "TWD"
-                let convertToSym = sharedUserDefaults.value(forKey: "convertToSym") as! String? ?? "TWD"
+                let convertFromSym = sharedUserDefaults.value(forKey: "convertFromSym") as? String ?? "TWD"
+                let convertToSym = sharedUserDefaults.value(forKey: "convertToSym") as? String ?? "TWD"
                 let unit = Float32(truncating: selected)
                 
                 CurrencyConverter.shared.convert(from: convertFromSym, to: convertToSym, unit: unit) { (result, error) in
+                    guard error == nil else {
+                        validationHandler(true, (error as? RateDataError)?.message ?? CurrencyConverter.shared.rateDataStatus.message)
+                        return
+                    }
                     
                     //Add credit card FX rate
-                    let fxIndex = sharedUserDefaults.value(forKey: "fxRateIndex") as! Int? ?? 1
+                    let fxIndex = sharedUserDefaults.value(forKey: "fxRateIndex") as? Int ?? 1
                     let calculation = LegacyContextMenuCalculation.calculate(
                         rawResult: result,
                         unit: unit,

--- a/CurrencyConverter Extension/SafariExtensionHandler.swift
+++ b/CurrencyConverter Extension/SafariExtensionHandler.swift
@@ -44,9 +44,9 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                 let convertToSym = sharedUserDefaults.value(forKey: "convertToSym") as? String ?? "TWD"
                 let unit = Float32(truncating: selected)
                 
-                CurrencyConverter.shared.convert(from: convertFromSym, to: convertToSym, unit: unit) { (result, error) in
+                CurrencyConverter.shared.convertWithStatus(from: convertFromSym, to: convertToSym, unit: unit) { result, status, error in
                     guard error == nil else {
-                        validationHandler(true, (error as? RateDataError)?.message ?? CurrencyConverter.shared.rateDataStatus.message)
+                        validationHandler(true, (error as? RateDataError)?.message ?? status.message)
                         return
                     }
                     
@@ -64,7 +64,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                     let formatter = ConvertPasteboardFormatter.init(fromSymbol: convertFromSym, fromAmount: unit, toSymbol: convertToSym, toAmount: price)
                     let formattingIndex = sharedUserDefaults.value(forKey: "FormatIndex") as? Int ?? 0
                     let lastCurrencyExchangeStr = formatter.getFormattedString(formatIndex: formattingIndex)
-                    validationHandler(false, LegacyContextMenuPresentation.menuTitle(resultString: lastCurrencyExchangeStr, status: CurrencyConverter.shared.rateDataStatus))
+                    validationHandler(false, LegacyContextMenuPresentation.menuTitle(resultString: lastCurrencyExchangeStr, status: status))
                     let lastResult = LastResult(resultString: lastCurrencyExchangeStr, convertFrom: convertFromSym, convertTo: convertToSym, units: unit, fxRate: calculation.appliedFXFee, ratio: calculation.ratio)
                     sharedUserDefaults.set(try? LastResultPersistence.encode(lastResult), forKey: "lastResult")
                     

--- a/CurrencyConverter Extension/SafariExtensionViewController.swift
+++ b/CurrencyConverter Extension/SafariExtensionViewController.swift
@@ -109,7 +109,7 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
         guard let convertFromSym, let convertToSym else { return }
         cc.convertWithStatus(from: convertFromSym, to: convertToSym, unit: baseRateValueField.floatValue) { result, status, error in
             DispatchQueue.main.async {
-                self.statusText.stringValue = status.message
+                self.statusText.stringValue = (error as? RateDataError)?.message ?? status.message
                 guard error == nil else {
                     return
                 }
@@ -126,7 +126,7 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
         self.formatterListBtn.removeAllItems()
         cc.convertWithStatus(from: convertFromSym, to: convertToSym, unit: 1) { result, status, error in
             DispatchQueue.main.async {
-                self.statusText.stringValue = status.message
+                self.statusText.stringValue = (error as? RateDataError)?.message ?? status.message
                 guard error == nil else {
                     return
                 }

--- a/CurrencyConverter Extension/SafariExtensionViewController.swift
+++ b/CurrencyConverter Extension/SafariExtensionViewController.swift
@@ -14,7 +14,7 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     
     static let shared: SafariExtensionViewController = {
         let shared = SafariExtensionViewController()
-        shared.preferredContentSize = NSSize(width:330, height:120)
+        shared.preferredContentSize = NSSize(width:330, height:150)
         return shared
     }()
     
@@ -25,6 +25,7 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     
     @IBOutlet weak var formatterListBtn: NSPopUpButton!
     @IBOutlet weak var ratesText: NSTextField!
+    @IBOutlet weak var statusText: NSTextField!
     
     var convertFromSym : String?
     var convertToSym : String?
@@ -42,24 +43,28 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     override func viewDidLoad() {
         
         fxRateBtnList = [fxRateBtn0, fxRateBtn15, fxRateBtn2]
-        let fxRateIndex = sharedUserDefaults.value(forKey: "fxRateIndex") as! Int? ?? 1
+        let fxRateIndex = sharedUserDefaults.value(forKey: "fxRateIndex") as? Int ?? 1
         fxRateBtnList.forEach { $0.state = .off }
-        fxRateBtnList[fxRateIndex].state = .on
+        fxRateBtnList[min(max(fxRateIndex, 0), fxRateBtnList.count - 1)].state = .on
         
         let cc = CurrencyConverter.shared
         cc.getSymbols { (symbols, error) in
-            self.symbols = symbols?.sorted()
-            self.convertListBtn.removeAllItems()
-            self.convertToListBtn.removeAllItems()
-            self.convertListBtn.addItems(withTitles: self.symbols!)
-            self.convertToListBtn.addItems(withTitles: self.symbols!)
-            self.convertFromSym = sharedUserDefaults.value(forKey: "convertFromSym") as! String? ?? "USD"
-            self.convertToSym = sharedUserDefaults.value(forKey: "convertToSym") as! String? ?? "TWD"
-            self.convertListBtn.selectItem(at: self.symbols!.firstIndex(of: self.convertFromSym ?? "USD") ?? 0)
-            self.convertToListBtn.selectItem(at: self.symbols!.firstIndex(of: self.convertToSym ?? "TWD") ?? 0)
-            self.baseRateValueField.floatValue = sharedUserDefaults.value(forKey: "baseRateValue") as! Float32? ?? 1.0
-            self.UpdateFormatters()
-            self.UpdateRates()
+            DispatchQueue.main.async {
+                self.statusText.stringValue = error.map { ($0 as? RateDataError)?.message ?? "Exchange rates unavailable." } ?? cc.rateDataStatus.message
+                guard let symbols, !symbols.isEmpty else { return }
+                self.symbols = symbols.sorted()
+                self.convertListBtn.removeAllItems()
+                self.convertToListBtn.removeAllItems()
+                self.convertListBtn.addItems(withTitles: self.symbols ?? [])
+                self.convertToListBtn.addItems(withTitles: self.symbols ?? [])
+                self.convertFromSym = sharedUserDefaults.value(forKey: "convertFromSym") as? String ?? "USD"
+                self.convertToSym = sharedUserDefaults.value(forKey: "convertToSym") as? String ?? "TWD"
+                self.convertListBtn.selectItem(at: self.symbols?.firstIndex(of: self.convertFromSym ?? "USD") ?? 0)
+                self.convertToListBtn.selectItem(at: self.symbols?.firstIndex(of: self.convertToSym ?? "TWD") ?? 0)
+                self.baseRateValueField.floatValue = sharedUserDefaults.value(forKey: "baseRateValue") as? Float32 ?? 1.0
+                self.UpdateFormatters()
+                self.UpdateRates()
+            }
         }
     }
 
@@ -70,7 +75,8 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     }
     
     @IBAction func OnConvertFromClicked(_ sender: NSPopUpButton) {
-        let selected = symbols![sender.indexOfSelectedItem]
+        guard let symbols, symbols.indices.contains(sender.indexOfSelectedItem) else { return }
+        let selected = symbols[sender.indexOfSelectedItem]
         NSLog("ConvertFrom value selected : \(selected)")
         sharedUserDefaults.set(selected as String, forKey: "convertFromSym")
         convertFromSym = selected
@@ -79,7 +85,8 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     }
     
     @IBAction func OnConvertToClicked(_ sender: NSPopUpButton) {
-        let selected = symbols![sender.indexOfSelectedItem]
+        guard let symbols, symbols.indices.contains(sender.indexOfSelectedItem) else { return }
+        let selected = symbols[sender.indexOfSelectedItem]
         NSLog("ConvertTo value selected : \(selected)")
         sharedUserDefaults.set(selected as String, forKey: "convertToSym")
         convertToSym = selected
@@ -99,21 +106,35 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     
     func UpdateRates() {
         let cc = CurrencyConverter.shared
-        cc.convert(from: convertFromSym!, to: convertToSym!, unit: baseRateValueField.floatValue) { (result, error) in
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .currency
-            formatter.alwaysShowsDecimalSeparator = true
-            self.ratesText.stringValue = ":\(formatter.string(for: result)!)"
+        guard let convertFromSym, let convertToSym else { return }
+        cc.convert(from: convertFromSym, to: convertToSym, unit: baseRateValueField.floatValue) { result, error in
+            DispatchQueue.main.async {
+                guard error == nil else {
+                    self.statusText.stringValue = (error as? RateDataError)?.message ?? self.cc.rateDataStatus.message
+                    return
+                }
+                let formatter = NumberFormatter()
+                formatter.numberStyle = .currency
+                formatter.alwaysShowsDecimalSeparator = true
+                self.ratesText.stringValue = ":\(formatter.string(for: result) ?? "—")"
+            }
         }
     }
     
     func UpdateFormatters() {
+        guard let convertFromSym, let convertToSym else { return }
         self.formatterListBtn.removeAllItems()
-        cc.convert(from: self.convertFromSym!, to: self.convertToSym!, unit: 1) { (result, error) in
-            let cpf = ConvertPasteboardFormatter(fromSymbol: self.convertFromSym!, fromAmount: 1, toSymbol: self.convertToSym!, toAmount: result)
-            self.formatterListBtn.addItems(withTitles: cpf.getAllFormattedStrings())
+        cc.convert(from: convertFromSym, to: convertToSym, unit: 1) { result, error in
+            DispatchQueue.main.async {
+                guard error == nil else {
+                    self.statusText.stringValue = (error as? RateDataError)?.message ?? self.cc.rateDataStatus.message
+                    return
+                }
+                let cpf = ConvertPasteboardFormatter(fromSymbol: convertFromSym, fromAmount: 1, toSymbol: convertToSym, toAmount: result)
+                self.formatterListBtn.addItems(withTitles: cpf.getAllFormattedStrings())
+            }
         }
-        let formatIndex = sharedUserDefaults.value(forKey: "FormatIndex") as! Int? ?? 0
+        let formatIndex = sharedUserDefaults.value(forKey: "FormatIndex") as? Int ?? 0
         self.formatterListBtn.selectItem(at: formatIndex)
     }
 }

--- a/CurrencyConverter Extension/SafariExtensionViewController.swift
+++ b/CurrencyConverter Extension/SafariExtensionViewController.swift
@@ -107,10 +107,10 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     func UpdateRates() {
         let cc = CurrencyConverter.shared
         guard let convertFromSym, let convertToSym else { return }
-        cc.convert(from: convertFromSym, to: convertToSym, unit: baseRateValueField.floatValue) { result, error in
+        cc.convertWithStatus(from: convertFromSym, to: convertToSym, unit: baseRateValueField.floatValue) { result, status, error in
             DispatchQueue.main.async {
+                self.statusText.stringValue = status.message
                 guard error == nil else {
-                    self.statusText.stringValue = (error as? RateDataError)?.message ?? self.cc.rateDataStatus.message
                     return
                 }
                 let formatter = NumberFormatter()
@@ -124,10 +124,10 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     func UpdateFormatters() {
         guard let convertFromSym, let convertToSym else { return }
         self.formatterListBtn.removeAllItems()
-        cc.convert(from: convertFromSym, to: convertToSym, unit: 1) { result, error in
+        cc.convertWithStatus(from: convertFromSym, to: convertToSym, unit: 1) { result, status, error in
             DispatchQueue.main.async {
+                self.statusText.stringValue = status.message
                 guard error == nil else {
-                    self.statusText.stringValue = (error as? RateDataError)?.message ?? self.cc.rateDataStatus.message
                     return
                 }
                 let cpf = ConvertPasteboardFormatter(fromSymbol: convertFromSym, fromAmount: 1, toSymbol: convertToSym, toAmount: result)

--- a/CurrencyConverter Extension/SafariExtensionViewController.swift
+++ b/CurrencyConverter Extension/SafariExtensionViewController.swift
@@ -45,7 +45,7 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
         fxRateBtnList = [fxRateBtn0, fxRateBtn15, fxRateBtn2]
         let fxRateIndex = sharedUserDefaults.value(forKey: "fxRateIndex") as? Int ?? 1
         fxRateBtnList.forEach { $0.state = .off }
-        fxRateBtnList[min(max(fxRateIndex, 0), fxRateBtnList.count - 1)].state = .on
+        fxRateBtnList[fxRateIndex].state = .on
         
         let cc = CurrencyConverter.shared
         cc.getSymbols { (symbols, error) in

--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		63CC34012371982E00466679 /* LegacyContractSeams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34002371982E00466679 /* LegacyContractSeams.swift */; };
 		63CC34032371982E00466679 /* CCS34CharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */; };
 		63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */; };
+		63CC34312371982E00466679 /* CCS10RateFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */; };
 		625712FC2371982E00466679 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625712FB2371982E00466679 /* Cocoa.framework */; };
 		625712FF2371982E00466679 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625712FE2371982E00466679 /* SafariExtensionHandler.swift */; };
 		625713012371982E00466679 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625713002371982E00466679 /* SafariExtensionViewController.swift */; };
@@ -106,6 +107,7 @@
 		63CC34002371982E00466679 /* LegacyContractSeams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyContractSeams.swift; sourceTree = "<group>"; };
 		63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS34CharacterizationTests.swift; sourceTree = "<group>"; };
 		63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS17RefreshCoalescingTests.swift; sourceTree = "<group>"; };
+		63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS10RateFallbackTests.swift; sourceTree = "<group>"; };
 		625712E62371982E00466679 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		625712F62371982E00466679 /* CurrencyConverter Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CurrencyConverter Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		625712FB2371982E00466679 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -195,6 +197,7 @@
 				625712E42371982E00466679 /* CurrencyConverterTests.swift */,
 				63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */,
 				63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */,
+				63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */,
 				625712E62371982E00466679 /* Info.plist */,
 				62985BB6238464640022ED28 /* ConvertPasteboardFormatterTest.swift */,
 			);
@@ -423,6 +426,7 @@
 				63CC34142531982E00466679 /* EntityDetailRowPresentation.swift in Sources */,
 				63CC34032371982E00466679 /* CCS34CharacterizationTests.swift in Sources */,
 				63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */,
+				63CC34312371982E00466679 /* CCS10RateFallbackTests.swift in Sources */,
 				6257131C23719B5300466679 /* CurrencyConverter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CurrencyConverter/APISyncInfoView.swift
+++ b/CurrencyConverter/APISyncInfoView.swift
@@ -27,6 +27,13 @@ struct APISyncInfoView: View {
                 Spacer()
             }.frame(alignment: .leading)
             HStack {
+                Text("Rate status : ")
+                    .font(.system(.body, design: Font.Design.rounded))
+                    .frame(width: 200, alignment: .leading)
+                Text(host.rateStatus.message)
+                Spacer()
+            }.frame(alignment: .leading)
+            HStack {
                 Text("Raw Data : ")
                     .font(.system(.body, design: Font.Design.rounded))
                     .frame(width: 200, alignment: .leading)

--- a/CurrencyConverter/ApiSyncInfoViewModel.swift
+++ b/CurrencyConverter/ApiSyncInfoViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 class ApiSyncInfoViewModel : ObservableObject {
     @Published var data: ApiSyncInfoViewModel?
+    @Published private(set) var rateStatus = CurrencyConverter.shared.rateDataStatus
     var userDefaults: UserDefaults
     var lastUpdate: String?
     var parsedPayloadUpdate: String?
@@ -24,15 +25,22 @@ class ApiSyncInfoViewModel : ObservableObject {
         self.userDefaults = host
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
-        lastUpdate = formatter.string(from: host.object(forKey: "LastUpdateDate") as! Date)
+        if let date = host.object(forKey: "LastUpdateDate") as? Date {
+            lastUpdate = formatter.string(from: date)
+        } else {
+            lastUpdate = nil
+        }
         parsedPayloadUpdate = formatter.string(from: Date(timeIntervalSince1970: TimeInterval(host.integer(forKey: "CurrencyDataTime"))))
         rawData = host.string(forKey: "CurrencyDataRaw")
+        rateStatus = CurrencyConverter.shared.rateDataStatus
         data = self
     }
     
     func sync() {
-        CurrencyConverter.shared.loadFromWeb { [self] (error) in
-            loadFromUserDefaults(sharedUserDefaults)
+        CurrencyConverter.shared.loadFromWeb { [self] _ in
+            DispatchQueue.main.async {
+                self.loadFromUserDefaults(sharedUserDefaults)
+            }
         }
     }
 }

--- a/CurrencyConverter/ApiSyncInfoViewModel.swift
+++ b/CurrencyConverter/ApiSyncInfoViewModel.swift
@@ -21,7 +21,7 @@ class ApiSyncInfoViewModel : ObservableObject {
         loadFromUserDefaults(host)
     }
     
-    func loadFromUserDefaults(_ host : UserDefaults) {
+    func loadFromUserDefaults(_ host : UserDefaults, rateStatus: RateDataStatus? = nil) {
         self.userDefaults = host
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
@@ -32,14 +32,15 @@ class ApiSyncInfoViewModel : ObservableObject {
         }
         parsedPayloadUpdate = formatter.string(from: Date(timeIntervalSince1970: TimeInterval(host.integer(forKey: "CurrencyDataTime"))))
         rawData = host.string(forKey: "CurrencyDataRaw")
-        rateStatus = CurrencyConverter.shared.rateDataStatus
+        self.rateStatus = rateStatus ?? CurrencyConverter.shared.rateDataStatus
         data = self
     }
     
     func sync() {
         CurrencyConverter.shared.loadFromWeb { [self] _ in
             DispatchQueue.main.async {
-                self.loadFromUserDefaults(sharedUserDefaults)
+                let refreshedStatus = CurrencyConverter.shared.rateDataStatus
+                self.loadFromUserDefaults(sharedUserDefaults, rateStatus: refreshedStatus)
             }
         }
     }

--- a/CurrencyConverter/ApiSyncInfoViewModel.swift
+++ b/CurrencyConverter/ApiSyncInfoViewModel.swift
@@ -38,8 +38,8 @@ class ApiSyncInfoViewModel : ObservableObject {
     
     func sync() {
         CurrencyConverter.shared.loadFromWeb { [self] _ in
+            let refreshedStatus = CurrencyConverter.shared.rateDataStatus
             DispatchQueue.main.async {
-                let refreshedStatus = CurrencyConverter.shared.rateDataStatus
                 self.loadFromUserDefaults(sharedUserDefaults, rateStatus: refreshedStatus)
             }
         }

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -7,6 +7,7 @@ private final class CCS10Transport {
     private let lock = NSLock()
     private var completions: [Completion] = []
     private var requestCountValue = 0
+    private let requestStarted = DispatchSemaphore(value: 0)
 
     var requestCount: Int {
         lock.lock()
@@ -19,13 +20,29 @@ private final class CCS10Transport {
         requestCountValue += 1
         completions.append(completion)
         lock.unlock()
+        requestStarted.signal()
     }
 
-    func finish(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
+    func waitForRequest() -> Bool {
+        guard requestStarted.wait(timeout: .now() + 1) == .success else {
+            XCTFail("request start timeout")
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    func finish(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) -> Bool {
         lock.lock()
+        guard !completions.isEmpty else {
+            lock.unlock()
+            XCTFail("No pending transport completion to drain")
+            return false
+        }
         let completion = completions.removeFirst()
         lock.unlock()
         completion(data, response, error)
+        return true
     }
 }
 
@@ -83,7 +100,8 @@ final class CCS10RateFallbackTests: XCTestCase {
             }
         }
         XCTAssertEqual(transport.requestCount, 1)
-        transport.finish(error: URLError(.notConnectedToInternet))
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(error: URLError(.notConnectedToInternet)) else { return }
         wait(for: [completion], timeout: 1)
 
         XCTAssertEqual(errors, [.transport, .transport])
@@ -117,10 +135,11 @@ final class CCS10RateFallbackTests: XCTestCase {
             completion.fulfill()
         }
         XCTAssertEqual(transport.requestCount, 1)
-        transport.finish(
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(
             data: Data(#"{"message":"ignored"}"#.utf8),
             response: HTTPURLResponse(url: response.url!, statusCode: 503, httpVersion: nil, headerFields: nil)
-        )
+        ) else { return }
         wait(for: [completion], timeout: 1)
 
         XCTAssertEqual(defaults.object(forKey: "LastUpdateDate") as? Date, updated)
@@ -142,10 +161,11 @@ final class CCS10RateFallbackTests: XCTestCase {
             XCTAssertFalse(converter.rateDataStatus.message.contains("ignored"))
             completion.fulfill()
         }
-        transport.finish(
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(
             data: Data(#"{"base":"EUR","date":"2026-07-18","rates":{},"timestamp":123}"#.utf8),
             response: response
-        )
+        ) else { return }
         wait(for: [completion], timeout: 1)
     }
 
@@ -159,7 +179,8 @@ final class CCS10RateFallbackTests: XCTestCase {
             XCTAssertNil(converter.currencyRateEntity)
             completion.fulfill()
         }
-        transport.finish(data: Data("not-json".utf8), response: response)
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(data: Data("not-json".utf8), response: response) else { return }
         wait(for: [completion], timeout: 1)
     }
 
@@ -173,7 +194,8 @@ final class CCS10RateFallbackTests: XCTestCase {
             XCTAssertNil(converter.currencyRateEntity)
             completion.fulfill()
         }
-        transport.finish(data: Data(), response: nil)
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(data: Data(), response: nil) else { return }
         wait(for: [completion], timeout: 1)
     }
 
@@ -206,7 +228,8 @@ final class CCS10RateFallbackTests: XCTestCase {
             XCTAssertEqual(error as? RateDataError, .transport)
             failed.fulfill()
         }
-        transport.finish(error: URLError(.cannotLoadFromNetwork))
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(error: URLError(.cannotLoadFromNetwork)) else { return }
         wait(for: [failed], timeout: 1)
 
         let recovered = expectation(description: "recovery")
@@ -219,11 +242,158 @@ final class CCS10RateFallbackTests: XCTestCase {
             recovered.fulfill()
         }
         XCTAssertEqual(transport.requestCount, 2)
-        transport.finish(
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(
             data: Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":1.2},"timestamp":456}"#.utf8),
             response: response
-        )
+        ) else { return }
         wait(for: [recovered], timeout: 1)
+    }
+
+    func testFreshDefaultsReplaceStaleMemoryWithoutTransport() {
+        let transport = CCS10Transport()
+        let defaults = CCS10Defaults()
+        defaults.set(now, forKey: "LastUpdateDate")
+        defaults.set(["USD": Float32(2)], forKey: "CurrencyData")
+        defaults.set(456, forKey: "CurrencyDataTime")
+        let converter = makeConverter(defaults: defaults, transport: transport)
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-16", rates: ["USD": 1],
+            fetched_localtime: now.addingTimeInterval(-2 * LegacyCachePolicy.lifetime), timestamp: 123
+        )
+
+        XCTAssertTrue(converter.loadFromDefaults())
+        XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 2)
+        XCTAssertEqual(converter.currencyRateEntity?.timestamp, 456)
+        XCTAssertEqual(converter.rateDataStatus.source, .defaults)
+        XCTAssertFalse(converter.rateDataStatus.isStale)
+        XCTAssertNil(converter.rateDataStatus.lastRefreshError)
+        XCTAssertEqual(transport.requestCount, 0)
+    }
+
+    func testDefaultsUsePersistedBaseRawDateAndExistingRateMetadata() {
+        let defaults = CCS10Defaults()
+        let fetchedAt = now.addingTimeInterval(-60)
+        defaults.set(fetchedAt, forKey: "LastUpdateDate")
+        defaults.set(["USD": Float32(2)], forKey: "CurrencyData")
+        defaults.set("GBP", forKey: "CurrencyBase")
+        defaults.set(456, forKey: "CurrencyDataTime")
+        defaults.set(#"{"base":"JPY","date":"2025-01-02","rates":{"USD":999},"timestamp":999}"#, forKey: "CurrencyDataRaw")
+        let converter = makeConverter(defaults: defaults, transport: CCS10Transport())
+
+        XCTAssertTrue(converter.loadFromDefaults())
+        XCTAssertEqual(converter.currencyRateEntity?.base, "GBP")
+        XCTAssertEqual(converter.currencyRateEntity?.date, "2025-01-02")
+        XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 2)
+        XCTAssertEqual(converter.currencyRateEntity?.timestamp, 456)
+    }
+
+    func testLegacyDefaultsUseFetchDateAndEURWhenRawDateAndBaseAreMissing() {
+        let defaults = CCS10Defaults()
+        let fetchedAt = now.addingTimeInterval(-60)
+        defaults.set(fetchedAt, forKey: "LastUpdateDate")
+        defaults.set(["USD": Float32(2)], forKey: "CurrencyData")
+        defaults.set(456, forKey: "CurrencyDataTime")
+        defaults.set(#"{"base":"JPY","date":"","rates":{"USD":999},"timestamp":999}"#, forKey: "CurrencyDataRaw")
+        let converter = makeConverter(defaults: defaults, transport: CCS10Transport())
+
+        XCTAssertTrue(converter.loadFromDefaults())
+        XCTAssertEqual(converter.currencyRateEntity?.base, "EUR")
+        XCTAssertEqual(converter.currencyRateEntity?.date, "1970-01-01")
+        XCTAssertEqual(converter.currencyRateEntity?.timestamp, 456)
+    }
+
+    func testClockMayReadStatusDuringSetterAndMemoryLoad() {
+        let finished = expectation(description: "reentrant clock operations finish")
+        var converter: CurrencyConverter!
+        converter = CurrencyConverter(
+            clock: {
+                _ = converter.rateDataStatus
+                return self.now
+            },
+            defaults: CCS10Defaults(),
+            transport: CCS10Transport().send
+        )
+
+        DispatchQueue.global().async {
+            converter.currencyRateEntity = CurrencyRateEntity(
+                base: "EUR", date: "2026-07-18", rates: ["USD": 1], fetched_localtime: self.now, timestamp: 123
+            )
+            XCTAssertTrue(converter.loadFromMemory())
+            finished.fulfill()
+        }
+        wait(for: [finished], timeout: 1)
+    }
+
+    func testFirstConversionRefreshFailureFallsBackToLKGWithoutSecondRequest() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-16", rates: ["USD": 1, "JPY": 110],
+            fetched_localtime: now.addingTimeInterval(-2 * LegacyCachePolicy.lifetime), timestamp: 123
+        )
+        let conversion = expectation(description: "first conversion uses LKG")
+
+        converter.convert(from: "JPY", to: "USD", unit: 110) { amount, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(amount, 1, accuracy: 0.0001)
+            conversion.fulfill()
+        }
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(error: URLError(.notConnectedToInternet)) else { return }
+        wait(for: [conversion], timeout: 1)
+        XCTAssertEqual(transport.requestCount, 1)
+
+        let secondConversion = expectation(description: "second conversion reuses LKG")
+        converter.convert(from: "JPY", to: "USD", unit: 220) { amount, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(amount, 2, accuracy: 0.0001)
+            secondConversion.fulfill()
+        }
+        wait(for: [secondConversion], timeout: 1)
+        XCTAssertEqual(transport.requestCount, 1)
+    }
+
+    func testGetSymbolsUsesLKGAfterRefreshFailure() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-16", rates: ["USD": 1, "JPY": 110],
+            fetched_localtime: now.addingTimeInterval(-2 * LegacyCachePolicy.lifetime), timestamp: 123
+        )
+        let symbols = expectation(description: "symbols use LKG")
+
+        converter.getSymbols { result, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(Set(result ?? []), ["USD", "JPY"])
+            symbols.fulfill()
+        }
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(error: URLError(.notConnectedToInternet)) else { return }
+        wait(for: [symbols], timeout: 1)
+        XCTAssertEqual(transport.requestCount, 1)
+    }
+
+    func testSynchronousSuccessfulTransportCompletesTypedLoad() {
+        let converter = CurrencyConverter(
+            clock: { self.now },
+            defaults: CCS10Defaults(),
+            transport: { _, completion in
+                completion(
+                    Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":1.2},"timestamp":456}"#.utf8),
+                    self.response,
+                    nil
+                )
+            }
+        )
+        let loaded = expectation(description: "synchronous transport")
+
+        converter.loadData { error in
+            XCTAssertNil(error)
+            XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 1.2)
+            loaded.fulfill()
+        }
+        wait(for: [loaded], timeout: 1)
     }
 
     func testPresentationInputDistinguishesStaleAndUnavailable() {
@@ -235,9 +405,15 @@ final class CCS10RateFallbackTests: XCTestCase {
             RateDataStatus(source: nil, isStale: false, lastUpdated: nil, lastRefreshError: .unavailable).message,
             "Exchange rates unavailable."
         )
+        let title = LegacyContextMenuPresentation.menuTitle(
+            resultString: String(repeating: "x", count: 200),
+            status: RateDataStatus(source: .defaults, isStale: true, lastUpdated: nil, lastRefreshError: .transport)
+        )
+        XCTAssertEqual(title.count, 120)
+        XCTAssertTrue(title.hasSuffix("saved rates; refresh failed"))
     }
 
-    private func makeConverter(transport: CCS10Transport) -> CurrencyConverter {
-        CurrencyConverter(clock: { self.now }, defaults: CCS10Defaults(), transport: transport.send)
+    private func makeConverter(defaults: CCS10Defaults = CCS10Defaults(), transport: CCS10Transport) -> CurrencyConverter {
+        CurrencyConverter(clock: { self.now }, defaults: defaults, transport: transport.send)
     }
 }

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+@testable import CurrencyConverter
+
+private final class CCS10Transport {
+    typealias Completion = (Data?, URLResponse?, Error?) -> Void
+
+    private let lock = NSLock()
+    private var completions: [Completion] = []
+    private var requestCountValue = 0
+
+    var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestCountValue
+    }
+
+    func send(_ url: URL, completion: @escaping Completion) {
+        lock.lock()
+        requestCountValue += 1
+        completions.append(completion)
+        lock.unlock()
+    }
+
+    func finish(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
+        lock.lock()
+        let completion = completions.removeFirst()
+        lock.unlock()
+        completion(data, response, error)
+    }
+}
+
+private final class CCS10Defaults: UserDefaults {
+    private let lock = NSLock()
+    private var storage: [String: Any] = [:]
+
+    override func object(forKey defaultName: String) -> Any? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage[defaultName]
+    }
+
+    override func value(forKey key: String) -> Any? { object(forKey: key) }
+
+    override func integer(forKey defaultName: String) -> Int {
+        object(forKey: defaultName) as? Int ?? 0
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage[defaultName] = value
+    }
+}
+
+final class CCS10RateFallbackTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1000)
+    private let response = HTTPURLResponse(
+        url: URL(string: "https://example.test")!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+
+    func testTransportFailureFansOutAndConversionUsesStaleMemoryWithoutSecondRequest() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        let original = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-16", rates: ["USD": 1, "JPY": 110],
+            fetched_localtime: now.addingTimeInterval(-2 * LegacyCachePolicy.lifetime), timestamp: 123
+        )
+        converter.currencyRateEntity = original
+        let completion = expectation(description: "joined load callers")
+        completion.expectedFulfillmentCount = 2
+        var errors: [RateDataError?] = []
+        let errorLock = NSLock()
+
+        for _ in 0..<2 {
+            converter.loadData { error in
+                errorLock.lock()
+                errors.append(error as? RateDataError)
+                errorLock.unlock()
+                completion.fulfill()
+            }
+        }
+        XCTAssertEqual(transport.requestCount, 1)
+        transport.finish(error: URLError(.notConnectedToInternet))
+        wait(for: [completion], timeout: 1)
+
+        XCTAssertEqual(errors, [.transport, .transport])
+        XCTAssertEqual(converter.currencyRateEntity?.rates, original.rates)
+        XCTAssertEqual(converter.rateDataStatus.source, .memory)
+        XCTAssertTrue(converter.rateDataStatus.isStale)
+        XCTAssertEqual(converter.rateDataStatus.lastRefreshError, .transport)
+
+        let conversion = expectation(description: "stale conversion")
+        converter.convert(from: "JPY", to: "USD", unit: 110) { amount, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(amount, 1, accuracy: 0.0001)
+            conversion.fulfill()
+        }
+        wait(for: [conversion], timeout: 1)
+        XCTAssertEqual(transport.requestCount, 1)
+    }
+
+    func testHTTPFailureKeepsStaleDefaultsAndTimestamp() {
+        let transport = CCS10Transport()
+        let defaults = CCS10Defaults()
+        let updated = now.addingTimeInterval(-2 * LegacyCachePolicy.lifetime)
+        defaults.set(updated, forKey: "LastUpdateDate")
+        defaults.set(["USD": Float32(1)], forKey: "CurrencyData")
+        defaults.set(123, forKey: "CurrencyDataTime")
+        let converter = CurrencyConverter(clock: { self.now }, defaults: defaults, transport: transport.send)
+
+        let completion = expectation(description: "http failure")
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .httpStatus(503))
+            completion.fulfill()
+        }
+        XCTAssertEqual(transport.requestCount, 1)
+        transport.finish(
+            data: Data(#"{"message":"ignored"}"#.utf8),
+            response: HTTPURLResponse(url: response.url!, statusCode: 503, httpVersion: nil, headerFields: nil)
+        )
+        wait(for: [completion], timeout: 1)
+
+        XCTAssertEqual(defaults.object(forKey: "LastUpdateDate") as? Date, updated)
+        XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 1)
+        XCTAssertEqual(converter.rateDataStatus.source, .defaults)
+        XCTAssertTrue(converter.rateDataStatus.isStale)
+        XCTAssertEqual(converter.rateDataStatus.lastRefreshError, .httpStatus(503))
+    }
+
+    func testInvalidPayloadWithoutCacheReturnsBoundedTypedError() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        let completion = expectation(description: "invalid payload")
+
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .invalidPayload)
+            XCTAssertNil(converter.currencyRateEntity)
+            XCTAssertEqual(converter.rateDataStatus.source, nil)
+            XCTAssertFalse(converter.rateDataStatus.message.contains("ignored"))
+            completion.fulfill()
+        }
+        transport.finish(
+            data: Data(#"{"base":"EUR","date":"2026-07-18","rates":{},"timestamp":123}"#.utf8),
+            response: response
+        )
+        wait(for: [completion], timeout: 1)
+    }
+
+    func testDecodeFailureWithoutCacheReturnsTypedDecodeError() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        let completion = expectation(description: "decode failure")
+
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .decode)
+            XCTAssertNil(converter.currencyRateEntity)
+            completion.fulfill()
+        }
+        transport.finish(data: Data("not-json".utf8), response: response)
+        wait(for: [completion], timeout: 1)
+    }
+
+    func testMissingHTTPResponseWithoutCacheReturnsUnavailableError() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        let completion = expectation(description: "unavailable response")
+
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .unavailable)
+            XCTAssertNil(converter.currencyRateEntity)
+            completion.fulfill()
+        }
+        transport.finish(data: Data(), response: nil)
+        wait(for: [completion], timeout: 1)
+    }
+
+    func testMissingRateIsTypedAndDoesNotCrash() {
+        let converter = makeConverter(transport: CCS10Transport())
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-18", rates: ["USD": 1],
+            fetched_localtime: now, timestamp: 123
+        )
+        let completion = expectation(description: "missing rate")
+
+        converter.convert(from: "JPY", to: "USD", unit: 1) { amount, error in
+            XCTAssertEqual(amount, 0)
+            XCTAssertEqual(error as? RateDataError, .missingRate("JPY"))
+            completion.fulfill()
+        }
+        wait(for: [completion], timeout: 1)
+    }
+
+    func testValidRefreshAtomicallyReplacesSnapshotAndClearsFailureStatus() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-16", rates: ["USD": 1],
+            fetched_localtime: now.addingTimeInterval(-2 * LegacyCachePolicy.lifetime), timestamp: 123
+        )
+
+        let failed = expectation(description: "first failure")
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .transport)
+            failed.fulfill()
+        }
+        transport.finish(error: URLError(.cannotLoadFromNetwork))
+        wait(for: [failed], timeout: 1)
+
+        let recovered = expectation(description: "recovery")
+        converter.loadData { error in
+            XCTAssertNil(error)
+            XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 1.2)
+            XCTAssertEqual(converter.rateDataStatus.source, .web)
+            XCTAssertFalse(converter.rateDataStatus.isStale)
+            XCTAssertNil(converter.rateDataStatus.lastRefreshError)
+            recovered.fulfill()
+        }
+        XCTAssertEqual(transport.requestCount, 2)
+        transport.finish(
+            data: Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":1.2},"timestamp":456}"#.utf8),
+            response: response
+        )
+        wait(for: [recovered], timeout: 1)
+    }
+
+    func testPresentationInputDistinguishesStaleAndUnavailable() {
+        XCTAssertEqual(
+            RateDataStatus(source: .defaults, isStale: true, lastUpdated: nil, lastRefreshError: .decode).message,
+            "Using saved rates; refresh failed."
+        )
+        XCTAssertEqual(
+            RateDataStatus(source: nil, isStale: false, lastUpdated: nil, lastRefreshError: .unavailable).message,
+            "Exchange rates unavailable."
+        )
+    }
+
+    private func makeConverter(transport: CCS10Transport) -> CurrencyConverter {
+        CurrencyConverter(clock: { self.now }, defaults: CCS10Defaults(), transport: transport.send)
+    }
+}

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -46,7 +46,7 @@ private final class CCS10Transport {
     }
 }
 
-private final class CCS10Defaults: UserDefaults {
+private class CCS10Defaults: UserDefaults {
     private let lock = NSLock()
     private var storage: [String: Any] = [:]
 
@@ -66,6 +66,24 @@ private final class CCS10Defaults: UserDefaults {
         lock.lock()
         defer { lock.unlock() }
         storage[defaultName] = value
+    }
+}
+
+private final class CCS10SnapshotBarrierDefaults: CCS10Defaults {
+    let snapshotCaptured = DispatchSemaphore(value: 0)
+    let releaseSnapshot = DispatchSemaphore(value: 0)
+    var onSet: (() -> Void)?
+
+    override func integer(forKey defaultName: String) -> Int {
+        let value = super.integer(forKey: defaultName)
+        snapshotCaptured.signal()
+        _ = releaseSnapshot.wait(timeout: .now() + 2)
+        return value
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        onSet?()
+        super.set(value, forKey: defaultName)
     }
 }
 
@@ -164,6 +182,23 @@ final class CCS10RateFallbackTests: XCTestCase {
         guard transport.waitForRequest() else { return }
         guard transport.finish(
             data: Data(#"{"base":"EUR","date":"2026-07-18","rates":{},"timestamp":123}"#.utf8),
+            response: response
+        ) else { return }
+        wait(for: [completion], timeout: 1)
+    }
+
+    func testMalformedProviderDateIsInvalidPayload() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        let completion = expectation(description: "malformed provider date")
+
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .invalidPayload)
+            completion.fulfill()
+        }
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(
+            data: Data(#"{"base":"EUR","date":"2026-02-30","rates":{"USD":1.2},"timestamp":456}"#.utf8),
             response: response
         ) else { return }
         wait(for: [completion], timeout: 1)
@@ -288,6 +323,21 @@ final class CCS10RateFallbackTests: XCTestCase {
         XCTAssertEqual(converter.currencyRateEntity?.timestamp, 456)
     }
 
+    func testMalformedRawDateFallsBackToLastUpdateDateWithPersistedBasePrecedence() {
+        let defaults = CCS10Defaults()
+        let fetchedAt = now.addingTimeInterval(-60)
+        defaults.set(fetchedAt, forKey: "LastUpdateDate")
+        defaults.set(["USD": Float32(2)], forKey: "CurrencyData")
+        defaults.set("GBP", forKey: "CurrencyBase")
+        defaults.set(456, forKey: "CurrencyDataTime")
+        defaults.set(#"{"base":"JPY","date":"2026-02-30","rates":{"USD":999},"timestamp":999}"#, forKey: "CurrencyDataRaw")
+        let converter = makeConverter(defaults: defaults, transport: CCS10Transport())
+
+        XCTAssertTrue(converter.loadFromDefaults())
+        XCTAssertEqual(converter.currencyRateEntity?.base, "GBP")
+        XCTAssertEqual(converter.currencyRateEntity?.date, "1970-01-01")
+    }
+
     func testLegacyDefaultsUseFetchDateAndEURWhenRawDateAndBaseAreMissing() {
         let defaults = CCS10Defaults()
         let fetchedAt = now.addingTimeInterval(-60)
@@ -374,6 +424,27 @@ final class CCS10RateFallbackTests: XCTestCase {
         XCTAssertEqual(transport.requestCount, 1)
     }
 
+    func testInvalidStoredEntityDoesNotClassifyRefreshFailureAsMemory() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-02-30", rates: ["USD": 1],
+            fetched_localtime: now, timestamp: 123
+        )
+        let completion = expectation(description: "invalid stored entity failure")
+
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .transport)
+            XCTAssertNil(converter.rateDataStatus.source)
+            XCTAssertFalse(converter.rateDataStatus.isStale)
+            XCTAssertNil(converter.rateDataStatus.lastUpdated)
+            completion.fulfill()
+        }
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(error: URLError(.notConnectedToInternet)) else { return }
+        wait(for: [completion], timeout: 1)
+    }
+
     func testSynchronousSuccessfulTransportCompletesTypedLoad() {
         let converter = CurrencyConverter(
             clock: { self.now },
@@ -396,6 +467,46 @@ final class CCS10RateFallbackTests: XCTestCase {
         wait(for: [loaded], timeout: 1)
     }
 
+    func testDefaultsSnapshotCannotPublishOverCompetingWebCommit() {
+        let defaults = CCS10SnapshotBarrierDefaults()
+        defaults.set(now, forKey: "LastUpdateDate")
+        defaults.set(["USD": Float32(2)], forKey: "CurrencyData")
+        defaults.set(123, forKey: "CurrencyDataTime")
+        let transportStarted = DispatchSemaphore(value: 0)
+        let webPayload = Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":3.0},"timestamp":999}"#.utf8)
+        let converter = CurrencyConverter(
+            clock: { self.now },
+            defaults: defaults,
+            transport: { _, completion in
+                transportStarted.signal()
+                completion(webPayload, self.response, nil)
+            }
+        )
+        defaults.onSet = { _ = converter.rateDataStatus }
+        let loadFinished = DispatchSemaphore(value: 0)
+        let webFinished = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global().async {
+            XCTAssertTrue(converter.loadFromDefaults())
+            loadFinished.signal()
+        }
+        XCTAssertEqual(defaults.snapshotCaptured.wait(timeout: .now() + 1), .success)
+
+        DispatchQueue.global().async {
+            converter.loadFromWeb { error in
+                XCTAssertNil(error)
+                webFinished.signal()
+            }
+        }
+        XCTAssertEqual(transportStarted.wait(timeout: .now() + 1), .success)
+        defaults.releaseSnapshot.signal()
+
+        XCTAssertEqual(loadFinished.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(webFinished.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 3)
+        XCTAssertEqual(converter.rateDataStatus.source, .web)
+    }
+
     func testPresentationInputDistinguishesStaleAndUnavailable() {
         XCTAssertEqual(
             RateDataStatus(source: .defaults, isStale: true, lastUpdated: nil, lastRefreshError: .decode).message,
@@ -411,6 +522,38 @@ final class CCS10RateFallbackTests: XCTestCase {
         )
         XCTAssertEqual(title.count, 120)
         XCTAssertTrue(title.hasSuffix("saved rates; refresh failed"))
+    }
+
+    func testConversionPresentationUsesCapturedStaleStatusAfterConverterMutation() {
+        let transport = CCS10Transport()
+        let converter = makeConverter(transport: transport)
+        converter.currencyRateEntity = CurrencyRateEntity(
+            base: "EUR", date: "2026-07-16", rates: ["USD": 1, "JPY": 110],
+            fetched_localtime: now.addingTimeInterval(-2 * LegacyCachePolicy.lifetime), timestamp: 123
+        )
+        let failed = expectation(description: "refresh failure")
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .transport)
+            failed.fulfill()
+        }
+        guard transport.waitForRequest() else { return }
+        guard transport.finish(error: URLError(.notConnectedToInternet)) else { return }
+        wait(for: [failed], timeout: 1)
+
+        let converted = expectation(description: "conversion status snapshot")
+        converter.convertWithStatus(from: "JPY", to: "USD", unit: 110) { result, status, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(result, 1, accuracy: 0.0001)
+            XCTAssertTrue(status.isStale)
+            converter.currencyRateEntity = CurrencyRateEntity(
+                base: "EUR", date: "2026-07-18", rates: ["USD": 2, "JPY": 110],
+                fetched_localtime: self.now, timestamp: 456
+            )
+            let title = LegacyContextMenuPresentation.menuTitle(resultString: "1 USD", status: status)
+            XCTAssertTrue(title.hasSuffix("saved rates; refresh failed"))
+            converted.fulfill()
+        }
+        wait(for: [converted], timeout: 1)
     }
 
     private func makeConverter(defaults: CCS10Defaults = CCS10Defaults(), transport: CCS10Transport) -> CurrencyConverter {

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -507,7 +507,65 @@ final class CCS10RateFallbackTests: XCTestCase {
         XCTAssertEqual(converter.rateDataStatus.source, .web)
     }
 
+    func testSynchronousWebCommitRejectsReentrantDefaultsLoadBeforePublishingWebSnapshot() {
+        let defaults = CCS10SnapshotBarrierDefaults()
+        let webPayload = Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":3.0},"timestamp":999}"#.utf8)
+        let stateLock = NSLock()
+        var setCount = 0
+        var reentrantLoadResult: Bool?
+        var completionError: Error?
+        var converter: CurrencyConverter!
+        converter = CurrencyConverter(
+            clock: { self.now },
+            defaults: defaults,
+            transport: { _, completion in
+                completion(webPayload, self.response, nil)
+            }
+        )
+        defaults.onSet = {
+            stateLock.lock()
+            setCount += 1
+            let isFirstSet = setCount == 1
+            stateLock.unlock()
+
+            guard isFirstSet else { return }
+            let result = converter.loadFromDefaults()
+            stateLock.lock()
+            reentrantLoadResult = result
+            stateLock.unlock()
+        }
+        let commitFinished = expectation(description: "synchronous web commit")
+
+        DispatchQueue.global().async {
+            converter.loadFromWeb { error in
+                stateLock.lock()
+                completionError = error
+                stateLock.unlock()
+                commitFinished.fulfill()
+            }
+        }
+
+        wait(for: [commitFinished], timeout: 1)
+
+        stateLock.lock()
+        let observedSetCount = setCount
+        let observedReentrantLoadResult = reentrantLoadResult
+        let observedCompletionError = completionError
+        stateLock.unlock()
+        XCTAssertEqual(observedSetCount, 5)
+        XCTAssertEqual(observedReentrantLoadResult, false)
+        XCTAssertNil(observedCompletionError)
+        XCTAssertEqual(converter.currencyRateEntity?.rates["USD"], 3)
+        XCTAssertEqual(converter.rateDataStatus.source, .web)
+        XCTAssertFalse(converter.rateDataStatus.isStale)
+        XCTAssertNil(converter.rateDataStatus.lastRefreshError)
+    }
+
     func testPresentationInputDistinguishesStaleAndUnavailable() {
+        XCTAssertEqual(
+            RateDataStatus(source: .defaults, isStale: true, lastUpdated: nil, lastRefreshError: nil).message,
+            "Using saved rates; refresh pending."
+        )
         XCTAssertEqual(
             RateDataStatus(source: .defaults, isStale: true, lastUpdated: nil, lastRefreshError: .decode).message,
             "Using saved rates; refresh failed."
@@ -522,6 +580,13 @@ final class CCS10RateFallbackTests: XCTestCase {
         )
         XCTAssertEqual(title.count, 120)
         XCTAssertTrue(title.hasSuffix("saved rates; refresh failed"))
+        XCTAssertEqual(
+            LegacyContextMenuPresentation.menuTitle(
+                resultString: "1 USD",
+                status: RateDataStatus(source: .defaults, isStale: true, lastUpdated: nil, lastRefreshError: nil)
+            ),
+            "1 USD"
+        )
     }
 
     func testConversionPresentationUsesCapturedStaleStatusAfterConverterMutation() {

--- a/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
+++ b/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
@@ -200,7 +200,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         wait(for: [completionExpectation], timeout: 1)
 
         XCTAssertEqual(results.count, 16)
-        XCTAssertTrue(results.errors.allSatisfy { ($0 as NSError?) === failure })
+        XCTAssertTrue(results.errors.allSatisfy { ($0 as? RateDataError) == .transport })
         XCTAssertEqual(results.nilErrorCount, 0)
     }
 
@@ -211,7 +211,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         let failure = NSError(domain: "CCS17", code: 18)
 
         converter.loadData { error in
-            XCTAssertTrue((error as NSError?) === failure)
+            XCTAssertEqual(error as? RateDataError, .transport)
             failureExpectation.fulfill()
         }
         guard transport.waitForRequest() else { return }
@@ -285,7 +285,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
 
         let firstExpectation = expectation(description: "synchronous failure completion")
         converter.loadData { error in
-            XCTAssertTrue((error as NSError?) === failure)
+            XCTAssertEqual(error as? RateDataError, .transport)
             firstExpectation.fulfill()
         }
         wait(for: [firstExpectation], timeout: 1)
@@ -377,10 +377,10 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         completion: @escaping (Error?) -> Void
     ) -> Bool {
         let ready = DispatchGroup()
-        let start = DispatchSemaphore(value: 0)
+        let start = CCS17StartGate()
         for _ in 0..<count {
             ready.enter()
-            DispatchQueue.global().async {
+            DispatchQueue.global(qos: .userInitiated).async {
                 ready.leave()
                 start.wait()
                 converter.loadData(completionHandler: completion)
@@ -391,7 +391,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             return false
         }
         for _ in 0..<count {
-            start.signal()
+            start.open()
         }
         return true
     }
@@ -443,6 +443,26 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         XCTAssertEqual(results.count, 2)
         XCTAssertTrue(results.errors.allSatisfy { $0 == nil })
         XCTAssertTrue(results.rates.allSatisfy { $0 == Float32(1) })
+    }
+}
+
+private final class CCS17StartGate {
+    private let condition = NSCondition()
+    private var isOpen = false
+
+    func wait() {
+        condition.lock()
+        while !isOpen {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+
+    func open() {
+        condition.lock()
+        isOpen = true
+        condition.broadcast()
+        condition.unlock()
     }
 }
 

--- a/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
+++ b/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
@@ -377,10 +377,10 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         completion: @escaping (Error?) -> Void
     ) -> Bool {
         let ready = DispatchGroup()
-        let start = CCS17StartGate()
+        let start = DispatchSemaphore(value: 0)
         for _ in 0..<count {
             ready.enter()
-            DispatchQueue.global(qos: .userInitiated).async {
+            DispatchQueue.global().async {
                 ready.leave()
                 start.wait()
                 converter.loadData(completionHandler: completion)
@@ -391,7 +391,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
             return false
         }
         for _ in 0..<count {
-            start.open()
+            start.signal()
         }
         return true
     }
@@ -443,26 +443,6 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         XCTAssertEqual(results.count, 2)
         XCTAssertTrue(results.errors.allSatisfy { $0 == nil })
         XCTAssertTrue(results.rates.allSatisfy { $0 == Float32(1) })
-    }
-}
-
-private final class CCS17StartGate {
-    private let condition = NSCondition()
-    private var isOpen = false
-
-    func wait() {
-        condition.lock()
-        while !isOpen {
-            condition.wait()
-        }
-        condition.unlock()
-    }
-
-    func open() {
-        condition.lock()
-        isOpen = true
-        condition.broadcast()
-        condition.unlock()
     }
 }
 

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -62,6 +62,8 @@ class CurrencyConverter {
     private let clock: () -> Date
     private let defaults: UserDefaults
     private let transport: RateTransport
+    // When both are needed, defaultsLock is acquired before currencyRateEntityLock;
+    // injected defaults callbacks never run while the entity lock is held.
     private let defaultsLock = NSLock()
     private let refreshLock = NSLock()
     private var nextRefreshID: UInt64 = 0
@@ -190,22 +192,22 @@ class CurrencyConverter {
     }
     
     func loadFromDefaults() -> Bool {
+        let now = clock()
+        let formatter = providerDateFormatter()
+
         defaultsLock.lock()
+        defer { defaultsLock.unlock() }
         let recordValue = defaults.value(forKey: "LastUpdateDate")
         let ratesValue = defaults.value(forKey: "CurrencyData")
         let baseValue = defaults.value(forKey: "CurrencyBase")
         let rawDataValue = defaults.value(forKey: "CurrencyDataRaw")
         let dataTimestamp = defaults.integer(forKey: "CurrencyDataTime")
-        defaultsLock.unlock()
 
         guard let record = recordValue as? Date,
               let rates = ratesValue as? [String: Float32] else {
             return false
         }
 
-        let now = clock()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
         let rawEntity: CurrencyRateEntity? = {
             guard let rawDataString = rawDataValue as? String,
                   let rawData = rawDataString.data(using: .utf8),
@@ -217,7 +219,8 @@ class CurrencyConverter {
         }()
         let persistedBase = (baseValue as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let base = persistedBase.flatMap { $0.isEmpty ? nil : $0 } ?? rawEntity?.base ?? "EUR"
-        let date = rawEntity?.date ?? formatter.string(from: record)
+        let date = rawEntity.map { isValidProviderDate($0.date) ? $0.date : formatter.string(from: record) }
+            ?? formatter.string(from: record)
         let entity = CurrencyRateEntity(
             base: base, date: date, rates: rates,
             fetched_localtime: record, timestamp: dataTimestamp
@@ -228,6 +231,7 @@ class CurrencyConverter {
 
         let defaultsIsFresh = LegacyCachePolicy.isFresh(lastUpdated: record, now: now)
         currencyRateEntityLock.lock()
+        defer { currencyRateEntityLock.unlock() }
         let currentStatus = rateDataStatusStorage
         if defaultsIsFresh {
             currencyRateEntityStorage = entity
@@ -237,7 +241,6 @@ class CurrencyConverter {
                 lastUpdated: record,
                 lastRefreshError: nil
             )
-            currencyRateEntityLock.unlock()
             return true
         }
 
@@ -260,7 +263,6 @@ class CurrencyConverter {
                 lastRefreshError: currentStatus.lastRefreshError
             )
         }
-        currencyRateEntityLock.unlock()
         return false
     }
     
@@ -334,20 +336,36 @@ class CurrencyConverter {
     }
     
     func convert(from: String, to: String, unit: Float32, completionHandler: @escaping (Float32, Error?) -> Void) {
+        convertWithStatus(from: from, to: to, unit: unit) { result, _, error in
+            completionHandler(result, error)
+        }
+    }
+
+    func convertWithStatus(
+        from: String,
+        to: String,
+        unit: Float32,
+        completionHandler: @escaping (Float32, RateDataStatus, Error?) -> Void
+    ) {
         loadDataForUse { error in
-            guard let entity = self.currentUsableEntity() else {
-                completionHandler(0.0, error ?? RateDataError.unavailable)
+            let snapshot = self.currentUsableSnapshot()
+            guard let entity = snapshot.entity else {
+                completionHandler(0.0, snapshot.status, error ?? RateDataError.unavailable)
                 return
             }
             guard let fromRate = entity.rates[from] else {
-                completionHandler(0.0, RateDataError.missingRate(from))
+                completionHandler(0.0, snapshot.status, RateDataError.missingRate(from))
                 return
             }
             guard let toRate = entity.rates[to] else {
-                completionHandler(0.0, RateDataError.missingRate(to))
+                completionHandler(0.0, snapshot.status, RateDataError.missingRate(to))
                 return
             }
-            completionHandler(LegacyConversionMath.direct(unit: unit, fromRate: fromRate, toRate: toRate), nil)
+            completionHandler(
+                LegacyConversionMath.direct(unit: unit, fromRate: fromRate, toRate: toRate),
+                snapshot.status,
+                nil
+            )
         }
     }
     
@@ -373,10 +391,14 @@ class CurrencyConverter {
     }
 
     private func currentUsableEntity() -> CurrencyRateEntity? {
+        currentUsableSnapshot().entity
+    }
+
+    private func currentUsableSnapshot() -> (entity: CurrencyRateEntity?, status: RateDataStatus) {
         currencyRateEntityLock.lock()
         defer { currencyRateEntityLock.unlock() }
-        guard let entity = currencyRateEntityStorage, isUsableRateEntity(entity) else { return nil }
-        return entity
+        let entity = currencyRateEntityStorage.flatMap { isUsableRateEntity($0) ? $0 : nil }
+        return (entity, rateDataStatusStorage)
     }
 
     private func isUsableRateEntity(_ entity: CurrencyRateEntity) -> Bool {
@@ -385,7 +407,7 @@ class CurrencyConverter {
 
     private func isValidRateEntity(_ entity: CurrencyRateEntity) -> Bool {
         guard !entity.base.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !entity.date.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              isValidProviderDate(entity.date),
               !entity.rates.isEmpty else {
             return false
         }
@@ -396,12 +418,21 @@ class CurrencyConverter {
 
     private func recordRefreshFailure(_ error: RateDataError) {
         currencyRateEntityLock.lock()
-        let entity = currencyRateEntityStorage
-        let source = rateDataStatusStorage.source ?? (entity == nil ? nil : .memory)
+        guard let entity = currencyRateEntityStorage, isUsableRateEntity(entity) else {
+            rateDataStatusStorage = RateDataStatus(
+                source: nil,
+                isStale: false,
+                lastUpdated: nil,
+                lastRefreshError: error
+            )
+            currencyRateEntityLock.unlock()
+            return
+        }
+        let source = rateDataStatusStorage.source ?? .memory
         rateDataStatusStorage = RateDataStatus(
             source: source,
-            isStale: source != nil,
-            lastUpdated: entity?.fetched_localtime ?? rateDataStatusStorage.lastUpdated,
+            isStale: true,
+            lastUpdated: entity.fetched_localtime,
             lastRefreshError: error
         )
         currencyRateEntityLock.unlock()
@@ -409,14 +440,7 @@ class CurrencyConverter {
 
     private func commitWebSnapshot(_ entity: CurrencyRateEntity, rawData: Data, fetchedAt: Date) {
         defaultsLock.lock()
-        currencyRateEntityLock.lock()
-        currencyRateEntityStorage = entity
-        rateDataStatusStorage = RateDataStatus(
-            source: .web,
-            isStale: false,
-            lastUpdated: fetchedAt,
-            lastRefreshError: nil
-        )
+        defer { defaultsLock.unlock() }
         defaults.set(fetchedAt, forKey: "LastUpdateDate")
         defaults.set(entity.rates, forKey: "CurrencyData")
         defaults.set(entity.base, forKey: "CurrencyBase")
@@ -424,8 +448,31 @@ class CurrencyConverter {
         if let rawDataString = String(data: rawData, encoding: .utf8) {
             defaults.set(rawDataString, forKey: "CurrencyDataRaw")
         }
-        currencyRateEntityLock.unlock()
-        defaultsLock.unlock()
+        currencyRateEntityLock.lock()
+        defer { currencyRateEntityLock.unlock() }
+        currencyRateEntityStorage = entity
+        rateDataStatusStorage = RateDataStatus(
+            source: .web,
+            isStale: false,
+            lastUpdated: fetchedAt,
+            lastRefreshError: nil
+        )
+    }
+
+    private func providerDateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.isLenient = false
+        return formatter
+    }
+
+    private func isValidProviderDate(_ value: String) -> Bool {
+        let formatter = providerDateFormatter()
+        guard let date = formatter.date(from: value) else { return false }
+        return formatter.string(from: date) == value
     }
 
 }

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -409,15 +409,6 @@ class CurrencyConverter {
 
     private func commitWebSnapshot(_ entity: CurrencyRateEntity, rawData: Data, fetchedAt: Date) {
         defaultsLock.lock()
-        defaults.set(fetchedAt, forKey: "LastUpdateDate")
-        defaults.set(entity.rates, forKey: "CurrencyData")
-        defaults.set(entity.base, forKey: "CurrencyBase")
-        defaults.set(entity.timestamp, forKey: "CurrencyDataTime")
-        if let rawDataString = String(data: rawData, encoding: .utf8) {
-            defaults.set(rawDataString, forKey: "CurrencyDataRaw")
-        }
-        defaultsLock.unlock()
-
         currencyRateEntityLock.lock()
         currencyRateEntityStorage = entity
         rateDataStatusStorage = RateDataStatus(
@@ -426,7 +417,15 @@ class CurrencyConverter {
             lastUpdated: fetchedAt,
             lastRefreshError: nil
         )
+        defaults.set(fetchedAt, forKey: "LastUpdateDate")
+        defaults.set(entity.rates, forKey: "CurrencyData")
+        defaults.set(entity.base, forKey: "CurrencyBase")
+        defaults.set(entity.timestamp, forKey: "CurrencyDataTime")
+        if let rawDataString = String(data: rawData, encoding: .utf8) {
+            defaults.set(rawDataString, forKey: "CurrencyDataRaw")
+        }
         currencyRateEntityLock.unlock()
+        defaultsLock.unlock()
     }
 
 }

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -193,12 +193,12 @@ class CurrencyConverter {
     }
     
     func loadFromDefaults() -> Bool {
+        let now = clock()
+        let formatter = providerDateFormatter()
+
         defaultsLock.lock()
         defer { defaultsLock.unlock() }
         guard !isPersistingWebSnapshot else { return false }
-
-        let now = clock()
-        let formatter = providerDateFormatter()
 
         let recordValue = defaults.value(forKey: "LastUpdateDate")
         let ratesValue = defaults.value(forKey: "CurrencyData")

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -33,11 +33,16 @@ class CurrencyConverter {
             return currencyRateEntityStorage
         }
         set {
+            let now = newValue?.fetched_localtime == nil ? nil : clock()
+            let isStale = newValue?.fetched_localtime.map { fetchedAt in
+                guard let now else { return false }
+                return !LegacyCachePolicy.isFresh(lastUpdated: fetchedAt, now: now)
+            } ?? false
             currencyRateEntityLock.lock()
             currencyRateEntityStorage = newValue
             rateDataStatusStorage = RateDataStatus(
                 source: newValue == nil ? nil : .memory,
-                isStale: newValue?.fetched_localtime.map { !LegacyCachePolicy.isFresh(lastUpdated: $0, now: clock()) } ?? false,
+                isStale: isStale,
                 lastUpdated: newValue?.fetched_localtime,
                 lastRefreshError: nil
             )
@@ -188,6 +193,8 @@ class CurrencyConverter {
         defaultsLock.lock()
         let recordValue = defaults.value(forKey: "LastUpdateDate")
         let ratesValue = defaults.value(forKey: "CurrencyData")
+        let baseValue = defaults.value(forKey: "CurrencyBase")
+        let rawDataValue = defaults.value(forKey: "CurrencyDataRaw")
         let dataTimestamp = defaults.integer(forKey: "CurrencyDataTime")
         defaultsLock.unlock()
 
@@ -196,35 +203,69 @@ class CurrencyConverter {
             return false
         }
 
-        let today = clock()
+        let now = clock()
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
+        let rawEntity: CurrencyRateEntity? = {
+            guard let rawDataString = rawDataValue as? String,
+                  let rawData = rawDataString.data(using: .utf8),
+                  let decoded = try? JSONDecoder().decode(CurrencyRateEntity.self, from: rawData),
+                  isValidRateEntity(decoded) else {
+                return nil
+            }
+            return decoded
+        }()
+        let persistedBase = (baseValue as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = persistedBase.flatMap { $0.isEmpty ? nil : $0 } ?? rawEntity?.base ?? "EUR"
+        let date = rawEntity?.date ?? formatter.string(from: record)
         let entity = CurrencyRateEntity(
-            base: "EUR", date: formatter.string(from: today), rates: rates,
+            base: base, date: date, rates: rates,
             fetched_localtime: record, timestamp: dataTimestamp
         )
         guard isValidRateEntity(entity) else {
             return false
         }
 
+        let defaultsIsFresh = LegacyCachePolicy.isFresh(lastUpdated: record, now: now)
         currencyRateEntityLock.lock()
-        let hasValidMemory = currencyRateEntityStorage.map(isUsableRateEntity) ?? false
-        let hadRefreshError = rateDataStatusStorage.lastRefreshError != nil
-        if !hasValidMemory {
+        let currentStatus = rateDataStatusStorage
+        if defaultsIsFresh {
             currencyRateEntityStorage = entity
             rateDataStatusStorage = RateDataStatus(
                 source: .defaults,
-                isStale: !LegacyCachePolicy.isFresh(lastUpdated: record, now: today),
+                isStale: false,
                 lastUpdated: record,
-                lastRefreshError: rateDataStatusStorage.lastRefreshError
+                lastRefreshError: nil
+            )
+            currencyRateEntityLock.unlock()
+            return true
+        }
+
+        let memoryCandidate: (CurrencyRateEntity, RateDataSource)? = {
+            guard let memory = currencyRateEntityStorage,
+                  isUsableRateEntity(memory),
+                  memory.fetched_localtime != nil else {
+                return nil
+            }
+            let source = currentStatus.source ?? .memory
+            return (memory, source)
+        }()
+        let candidates: [(CurrencyRateEntity, RateDataSource)] = [memoryCandidate, (entity, .defaults)].compactMap { $0 }
+        if let selected = candidates.max(by: { ($0.0.fetched_localtime ?? .distantPast) < ($1.0.fetched_localtime ?? .distantPast) }) {
+            currencyRateEntityStorage = selected.0
+            rateDataStatusStorage = RateDataStatus(
+                source: selected.1,
+                isStale: true,
+                lastUpdated: selected.0.fetched_localtime,
+                lastRefreshError: currentStatus.lastRefreshError
             )
         }
-        let currentSource = rateDataStatusStorage.source
         currencyRateEntityLock.unlock()
-        return currentSource == .defaults && LegacyCachePolicy.isFresh(lastUpdated: record, now: today) && !hadRefreshError
+        return false
     }
     
     func loadFromMemory() -> Bool {
+        let now = clock()
         currencyRateEntityLock.lock()
         guard let c = currencyRateEntityStorage,
               isUsableRateEntity(c),
@@ -232,16 +273,15 @@ class CurrencyConverter {
             currencyRateEntityLock.unlock()
             return false
         }
-        let today = clock()
         let hadRefreshError = rateDataStatusStorage.lastRefreshError != nil
         let source = rateDataStatusStorage.source ?? .memory
         rateDataStatusStorage = RateDataStatus(
             source: source,
-            isStale: !LegacyCachePolicy.isFresh(lastUpdated: lastUpdate, now: today) || hadRefreshError,
+            isStale: !LegacyCachePolicy.isFresh(lastUpdated: lastUpdate, now: now) || hadRefreshError,
             lastUpdated: lastUpdate,
             lastRefreshError: rateDataStatusStorage.lastRefreshError
         )
-        let isFresh = LegacyCachePolicy.isFresh(lastUpdated: lastUpdate, now: today)
+        let isFresh = LegacyCachePolicy.isFresh(lastUpdated: lastUpdate, now: now)
         currencyRateEntityLock.unlock()
         return isFresh && !hadRefreshError
     }
@@ -376,6 +416,8 @@ class CurrencyConverter {
         if let rawDataString = String(data: rawData, encoding: .utf8) {
             defaults.set(rawDataString, forKey: "CurrencyDataRaw")
         }
+        defaultsLock.unlock()
+
         currencyRateEntityLock.lock()
         currencyRateEntityStorage = entity
         rateDataStatusStorage = RateDataStatus(
@@ -385,7 +427,6 @@ class CurrencyConverter {
             lastRefreshError: nil
         )
         currencyRateEntityLock.unlock()
-        defaultsLock.unlock()
     }
 
 }

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -64,7 +64,8 @@ class CurrencyConverter {
     private let transport: RateTransport
     // When both are needed, defaultsLock is acquired before currencyRateEntityLock;
     // injected defaults callbacks never run while the entity lock is held.
-    private let defaultsLock = NSLock()
+    private let defaultsLock = NSRecursiveLock()
+    private var isPersistingWebSnapshot = false
     private let refreshLock = NSLock()
     private var nextRefreshID: UInt64 = 0
     private var activeRefreshID: UInt64?
@@ -192,11 +193,13 @@ class CurrencyConverter {
     }
     
     func loadFromDefaults() -> Bool {
+        defaultsLock.lock()
+        defer { defaultsLock.unlock() }
+        guard !isPersistingWebSnapshot else { return false }
+
         let now = clock()
         let formatter = providerDateFormatter()
 
-        defaultsLock.lock()
-        defer { defaultsLock.unlock() }
         let recordValue = defaults.value(forKey: "LastUpdateDate")
         let ratesValue = defaults.value(forKey: "CurrencyData")
         let baseValue = defaults.value(forKey: "CurrencyBase")
@@ -440,7 +443,11 @@ class CurrencyConverter {
 
     private func commitWebSnapshot(_ entity: CurrencyRateEntity, rawData: Data, fetchedAt: Date) {
         defaultsLock.lock()
-        defer { defaultsLock.unlock() }
+        isPersistingWebSnapshot = true
+        defer {
+            isPersistingWebSnapshot = false
+            defaultsLock.unlock()
+        }
         defaults.set(fetchedAt, forKey: "LastUpdateDate")
         defaults.set(entity.rates, forKey: "CurrencyData")
         defaults.set(entity.base, forKey: "CurrencyBase")

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -20,6 +20,12 @@ struct CurrencyRateEntity : Decodable {
 class CurrencyConverter {
     private let currencyRateEntityLock = NSLock()
     private var currencyRateEntityStorage: CurrencyRateEntity?
+    private var rateDataStatusStorage = RateDataStatus(
+        source: nil,
+        isStale: false,
+        lastUpdated: nil,
+        lastRefreshError: nil
+    )
     var currencyRateEntity: CurrencyRateEntity? {
         get {
             currencyRateEntityLock.lock()
@@ -29,8 +35,20 @@ class CurrencyConverter {
         set {
             currencyRateEntityLock.lock()
             currencyRateEntityStorage = newValue
+            rateDataStatusStorage = RateDataStatus(
+                source: newValue == nil ? nil : .memory,
+                isStale: newValue?.fetched_localtime.map { !LegacyCachePolicy.isFresh(lastUpdated: $0, now: clock()) } ?? false,
+                lastUpdated: newValue?.fetched_localtime,
+                lastRefreshError: nil
+            )
             currencyRateEntityLock.unlock()
         }
+    }
+
+    var rateDataStatus: RateDataStatus {
+        currencyRateEntityLock.lock()
+        defer { currencyRateEntityLock.unlock() }
+        return rateDataStatusStorage
     }
 
     var context: NSExtensionContext?
@@ -104,87 +122,128 @@ class CurrencyConverter {
         } else {
             feed_url = URL(string: "http://data.fixer.io/api/latest?access_key=676ac77e5ce5d4b9a57ee6464ff84433&format=1")
         }
-        
-        print("Loading currency data from \(String(describing: feed_url?.absoluteString))")
 
-        transport(feed_url!, { (data, response, error) in
-            if let error = error {
-                print("Error: \(error.localizedDescription)")
-                completionHandler(error)
+        guard let feed_url else {
+            let error = RateDataError.unavailable
+            self.recordRefreshFailure(error)
+            completionHandler(error)
+            return
+        }
+
+        transport(feed_url, { (data, response, error) in
+            if error != nil {
+                let refreshError = RateDataError.transport
+                self.recordRefreshFailure(refreshError)
+                completionHandler(refreshError)
                 return
-            } else if let response = response as? HTTPURLResponse,let data = data {
-                print("Status code: \(response.statusCode)")
-                let decoder = JSONDecoder()
-                if var currencyRateEntity = try? decoder.decode(CurrencyRateEntity.self, from: data) {
-                    let now = self.clock()
-                    currencyRateEntity.fetched_localtime = now
-                    self.currencyRateEntity = currencyRateEntity
-
-                    // Save this to UserDefaults.
-                    self.defaultsLock.lock()
-                    self.defaults.set(now, forKey: "LastUpdateDate")
-                    self.defaults.set(currencyRateEntity.rates, forKey: "CurrencyData")
-                    self.defaults.set(currencyRateEntity.base, forKey:"CurrencyBase")
-                    self.defaults.set(currencyRateEntity.timestamp, forKey: "CurrencyDataTime")
-                    self.defaults.set(String(data: data, encoding: .utf8), forKey: "CurrencyDataRaw")
-                    self.defaultsLock.unlock()
-                }
             }
+
+            guard let response = response as? HTTPURLResponse else {
+                let refreshError = RateDataError.unavailable
+                self.recordRefreshFailure(refreshError)
+                completionHandler(refreshError)
+                return
+            }
+
+            guard (200..<300).contains(response.statusCode) else {
+                let refreshError = RateDataError.httpStatus(response.statusCode)
+                self.recordRefreshFailure(refreshError)
+                completionHandler(refreshError)
+                return
+            }
+
+            guard let data else {
+                let refreshError = RateDataError.unavailable
+                self.recordRefreshFailure(refreshError)
+                completionHandler(refreshError)
+                return
+            }
+
+            let decodedEntity: CurrencyRateEntity
+            do {
+                decodedEntity = try JSONDecoder().decode(CurrencyRateEntity.self, from: data)
+            } catch {
+                let refreshError = RateDataError.decode
+                self.recordRefreshFailure(refreshError)
+                completionHandler(refreshError)
+                return
+            }
+
+            guard self.isValidRateEntity(decodedEntity) else {
+                let refreshError = RateDataError.invalidPayload
+                self.recordRefreshFailure(refreshError)
+                completionHandler(refreshError)
+                return
+            }
+
+            let now = self.clock()
+            var validatedEntity = decodedEntity
+            validatedEntity.fetched_localtime = now
+            self.commitWebSnapshot(validatedEntity, rawData: data, fetchedAt: now)
             completionHandler(nil)
         })
     }
     
     func loadFromDefaults() -> Bool {
-        let today = clock()
-
         defaultsLock.lock()
         let recordValue = defaults.value(forKey: "LastUpdateDate")
         let ratesValue = defaults.value(forKey: "CurrencyData")
         let dataTimestamp = defaults.integer(forKey: "CurrencyDataTime")
         defaultsLock.unlock()
 
-        let record = recordValue as! Date?
-        guard let record = record else {
+        guard let record = recordValue as? Date,
+              let rates = ratesValue as? [String: Float32] else {
             return false
         }
 
-        guard LegacyCachePolicy.isFresh(lastUpdated: record, now: today) else {
-            return false
-        }
-
-        let rates = ratesValue as! [String:Float32]?
-        guard let rates else {
-            return false
-        }
-
-        print("Convert Rate Data is good from \(record) and now is \(today), load from defaults.")
+        let today = clock()
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
-        let todayString = formatter.string(from: today)
-        self.currencyRateEntity = CurrencyRateEntity(
-            base: "EUR", date: todayString, rates: rates, fetched_localtime: record, timestamp: dataTimestamp
+        let entity = CurrencyRateEntity(
+            base: "EUR", date: formatter.string(from: today), rates: rates,
+            fetched_localtime: record, timestamp: dataTimestamp
         )
-        return true
+        guard isValidRateEntity(entity) else {
+            return false
+        }
+
+        currencyRateEntityLock.lock()
+        let hasValidMemory = currencyRateEntityStorage.map(isUsableRateEntity) ?? false
+        let hadRefreshError = rateDataStatusStorage.lastRefreshError != nil
+        if !hasValidMemory {
+            currencyRateEntityStorage = entity
+            rateDataStatusStorage = RateDataStatus(
+                source: .defaults,
+                isStale: !LegacyCachePolicy.isFresh(lastUpdated: record, now: today),
+                lastUpdated: record,
+                lastRefreshError: rateDataStatusStorage.lastRefreshError
+            )
+        }
+        let currentSource = rateDataStatusStorage.source
+        currencyRateEntityLock.unlock()
+        return currentSource == .defaults && LegacyCachePolicy.isFresh(lastUpdated: record, now: today) && !hadRefreshError
     }
     
     func loadFromMemory() -> Bool {
-        guard let c = currencyRateEntity else {
+        currencyRateEntityLock.lock()
+        guard let c = currencyRateEntityStorage,
+              isUsableRateEntity(c),
+              let lastUpdate = c.fetched_localtime else {
+            currencyRateEntityLock.unlock()
             return false
         }
-        
-        guard let last_update = c.fetched_localtime else {
-            NSLog("loadFromMemory() fetched_localtime is null!")
-            return false
-        }
-        
         let today = clock()
-        guard LegacyCachePolicy.isFresh(lastUpdated: last_update, now: today) else {
-            NSLog("Convert Rate Data in Memory not found or too old (\(last_update) vs \(today)), load from Defaults....")
-            return false
-        }
-        
-        NSLog("Convert Rate Data in Memory is good (\(last_update) vs \(today))")
-        return true
+        let hadRefreshError = rateDataStatusStorage.lastRefreshError != nil
+        let source = rateDataStatusStorage.source ?? .memory
+        rateDataStatusStorage = RateDataStatus(
+            source: source,
+            isStale: !LegacyCachePolicy.isFresh(lastUpdated: lastUpdate, now: today) || hadRefreshError,
+            lastUpdated: lastUpdate,
+            lastRefreshError: rateDataStatusStorage.lastRefreshError
+        )
+        let isFresh = LegacyCachePolicy.isFresh(lastUpdated: lastUpdate, now: today)
+        currencyRateEntityLock.unlock()
+        return isFresh && !hadRefreshError
     }
     
     func loadData(completionHandler: @escaping (Error?) -> Void = {_ in }) {
@@ -235,32 +294,98 @@ class CurrencyConverter {
     }
     
     func convert(from: String, to: String, unit: Float32, completionHandler: @escaping (Float32, Error?) -> Void) {
-        loadData { (error) in
-            if error != nil {
-                completionHandler(0.0, error)
+        loadDataForUse { error in
+            guard let entity = self.currentUsableEntity() else {
+                completionHandler(0.0, error ?? RateDataError.unavailable)
                 return
             }
-
-            let rates = self.currencyRateEntity!.rates
-            let result = LegacyConversionMath.direct(
-                unit: unit,
-                fromRate: rates[from]!,
-                toRate: rates[to]!
-            )
-            completionHandler(result, nil)
+            guard let fromRate = entity.rates[from] else {
+                completionHandler(0.0, RateDataError.missingRate(from))
+                return
+            }
+            guard let toRate = entity.rates[to] else {
+                completionHandler(0.0, RateDataError.missingRate(to))
+                return
+            }
+            completionHandler(LegacyConversionMath.direct(unit: unit, fromRate: fromRate, toRate: toRate), nil)
         }
     }
     
     func getSymbols(completionHandler: @escaping ([String]?, Error?) -> Void) {
-        loadData { (error) in
-            if error != nil {
-                completionHandler(nil, error)
+        loadDataForUse { error in
+            guard let entity = self.currentUsableEntity() else {
+                completionHandler(nil, error ?? RateDataError.unavailable)
                 return
             }
-            let currencyRateEntity = self.currencyRateEntity!
-            let symbols = Array(currencyRateEntity.rates.keys)
-            completionHandler(symbols, nil)
+            completionHandler(Array(entity.rates.keys), nil)
         }
     }
-    
+
+    private func loadDataForUse(_ completionHandler: @escaping (Error?) -> Void) {
+        currencyRateEntityLock.lock()
+        let canUseLastKnownGood = currencyRateEntityStorage.map(isUsableRateEntity) == true && rateDataStatusStorage.lastRefreshError != nil
+        currencyRateEntityLock.unlock()
+        if canUseLastKnownGood {
+            completionHandler(nil)
+        } else {
+            loadData(completionHandler: completionHandler)
+        }
+    }
+
+    private func currentUsableEntity() -> CurrencyRateEntity? {
+        currencyRateEntityLock.lock()
+        defer { currencyRateEntityLock.unlock() }
+        guard let entity = currencyRateEntityStorage, isUsableRateEntity(entity) else { return nil }
+        return entity
+    }
+
+    private func isUsableRateEntity(_ entity: CurrencyRateEntity) -> Bool {
+        isValidRateEntity(entity) && entity.fetched_localtime != nil
+    }
+
+    private func isValidRateEntity(_ entity: CurrencyRateEntity) -> Bool {
+        guard !entity.base.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !entity.date.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !entity.rates.isEmpty else {
+            return false
+        }
+        return entity.rates.allSatisfy { symbol, rate in
+            !symbol.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && rate.isFinite && rate > 0
+        }
+    }
+
+    private func recordRefreshFailure(_ error: RateDataError) {
+        currencyRateEntityLock.lock()
+        let entity = currencyRateEntityStorage
+        let source = rateDataStatusStorage.source ?? (entity == nil ? nil : .memory)
+        rateDataStatusStorage = RateDataStatus(
+            source: source,
+            isStale: source != nil,
+            lastUpdated: entity?.fetched_localtime ?? rateDataStatusStorage.lastUpdated,
+            lastRefreshError: error
+        )
+        currencyRateEntityLock.unlock()
+    }
+
+    private func commitWebSnapshot(_ entity: CurrencyRateEntity, rawData: Data, fetchedAt: Date) {
+        defaultsLock.lock()
+        defaults.set(fetchedAt, forKey: "LastUpdateDate")
+        defaults.set(entity.rates, forKey: "CurrencyData")
+        defaults.set(entity.base, forKey: "CurrencyBase")
+        defaults.set(entity.timestamp, forKey: "CurrencyDataTime")
+        if let rawDataString = String(data: rawData, encoding: .utf8) {
+            defaults.set(rawDataString, forKey: "CurrencyDataRaw")
+        }
+        currencyRateEntityLock.lock()
+        currencyRateEntityStorage = entity
+        rateDataStatusStorage = RateDataStatus(
+            source: .web,
+            isStale: false,
+            lastUpdated: fetchedAt,
+            lastRefreshError: nil
+        )
+        currencyRateEntityLock.unlock()
+        defaultsLock.unlock()
+    }
+
 }

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -132,6 +132,17 @@ struct LastResult: Codable, Equatable {
     var ratio: Float
 }
 
+enum LegacyContextMenuPresentation {
+    private static let titleLimit = 120
+    private static let staleWarning = " — saved rates; refresh failed"
+
+    static func menuTitle(resultString: String, status: RateDataStatus) -> String {
+        let warning = status.isStale ? staleWarning : ""
+        let resultLimit = max(0, titleLimit - warning.count)
+        return String(resultString.prefix(resultLimit)) + warning
+    }
+}
+
 enum LastResultPersistence {
     static func encode(_ value: LastResult) throws -> Data {
         try JSONEncoder().encode(value)

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -43,7 +43,9 @@ struct RateDataStatus: Equatable {
             return lastRefreshError?.message ?? RateDataError.unavailable.message
         }
         if isStale {
-            return "Using saved rates; refresh failed."
+            return lastRefreshError == nil
+                ? "Using saved rates; refresh pending."
+                : "Using saved rates; refresh failed."
         }
         return lastRefreshError?.message ?? "Exchange rates are current."
     }
@@ -137,7 +139,7 @@ enum LegacyContextMenuPresentation {
     private static let staleWarning = " — saved rates; refresh failed"
 
     static func menuTitle(resultString: String, status: RateDataStatus) -> String {
-        let warning = status.isStale ? staleWarning : ""
+        let warning = status.isStale && status.lastRefreshError != nil ? staleWarning : ""
         let resultLimit = max(0, titleLimit - warning.count)
         return String(resultString.prefix(resultLimit)) + warning
     }

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -1,5 +1,54 @@
 import Foundation
 
+enum RateDataSource: Equatable {
+    case memory
+    case defaults
+    case web
+}
+
+enum RateDataError: Error, Equatable {
+    case transport
+    case httpStatus(Int)
+    case decode
+    case invalidPayload
+    case missingRate(String)
+    case unavailable
+
+    var message: String {
+        switch self {
+        case .transport:
+            return "Could not refresh exchange rates."
+        case .httpStatus(let status):
+            return "Rate service returned an HTTP \(status / 100)xx response."
+        case .decode:
+            return "Rate service returned unreadable data."
+        case .invalidPayload:
+            return "Rate service returned invalid data."
+        case .missingRate:
+            return "Requested currency rate unavailable."
+        case .unavailable:
+            return "Exchange rates unavailable."
+        }
+    }
+}
+
+struct RateDataStatus: Equatable {
+    let source: RateDataSource?
+    let isStale: Bool
+    let lastUpdated: Date?
+    let lastRefreshError: RateDataError?
+
+    var message: String {
+        guard source != nil else {
+            return lastRefreshError?.message ?? RateDataError.unavailable.message
+        }
+        if isStale {
+            return "Using saved rates; refresh failed."
+        }
+        return lastRefreshError?.message ?? "Exchange rates are current."
+    }
+}
+
 enum LegacyConversionMath {
     static func direct(unit: Float32, fromRate: Float32, toRate: Float32) -> Float32 {
         (unit / fromRate) * toRate


### PR DESCRIPTION
## Summary
- classify transport, HTTP, decode, invalid-payload, missing-rate, and unavailable failures
- preserve validated stale memory/defaults snapshots and expose thread-safe status
- wire bounded status to app API sync and Safari extension presentation
- add deterministic offline recovery/coalescing coverage

## Verification
- baseline: 32/32 passed
- final: 40/40 passed
- focused TSan: 16/16 passed, no race/runtime-warning matches
- app and extension builds passed

Do not merge; host gates and fresh review remain.