### PR TITLE
CCS-21

### DIFF
--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -421,7 +421,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				62C49F25252AA14600ED2E72 /* CHDataManager.swift in Sources */,
 				62B81E67254240C70015CC19 /* CreditCardProfile.swift in Sources */,
 				62B81E4A2542155D0015CC19 /* CurrencySymbolMap.swift in Sources */,
 				6257132323719BDC00466679 /* SharedPersistent.swift in Sources */,
@@ -436,7 +435,6 @@
 				63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */,
 				63CC34312371982E00466679 /* CCS10RateFallbackTests.swift in Sources */,
 				63CC34412371982E00466679 /* CCS21AtomicRenewTests.swift in Sources */,
-				63CC34512531982E00466679 /* AtomicRenew.swift in Sources */,
 				6257131C23719B5300466679 /* CurrencyConverter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -690,6 +688,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 8AA96R6MF3;
@@ -703,6 +702,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.rayer.CurrencyConverterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CurrencyConverter.app/Contents/MacOS/CurrencyConverter";
 			};
 			name = Debug;
 		};
@@ -710,6 +710,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 8AA96R6MF3;
@@ -723,6 +724,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.rayer.CurrencyConverterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CurrencyConverter.app/Contents/MacOS/CurrencyConverter";
 			};
 			name = Release;
 		};

--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -435,6 +435,8 @@
 				63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */,
 				63CC34312371982E00466679 /* CCS10RateFallbackTests.swift in Sources */,
 				63CC34412371982E00466679 /* CCS21AtomicRenewTests.swift in Sources */,
+				62C49F25252AA14600ED2E72 /* CHDataManager.swift in Sources */,
+				63CC34512531982E00466679 /* AtomicRenew.swift in Sources */,
 				6257131C23719B5300466679 /* CurrencyConverter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -688,7 +690,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 8AA96R6MF3;
@@ -702,7 +703,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.rayer.CurrencyConverterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CurrencyConverter.app/Contents/MacOS/CurrencyConverter";
 			};
 			name = Debug;
 		};
@@ -710,7 +710,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 8AA96R6MF3;
@@ -724,7 +723,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.rayer.CurrencyConverterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CurrencyConverter.app/Contents/MacOS/CurrencyConverter";
 			};
 			name = Release;
 		};

--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		63CC34032371982E00466679 /* CCS34CharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */; };
 		63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */; };
 		63CC34312371982E00466679 /* CCS10RateFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */; };
+		63CC34412371982E00466679 /* CCS21AtomicRenewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34402371982E00466679 /* CCS21AtomicRenewTests.swift */; };
+		63CC34512531982E00466679 /* AtomicRenew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34502531982E00466679 /* AtomicRenew.swift */; };
+		63CC34522531982E00466679 /* AtomicRenew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34502531982E00466679 /* AtomicRenew.swift */; };
+		63CC34532531982E00466679 /* AtomicRenew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34502531982E00466679 /* AtomicRenew.swift */; };
 		625712FC2371982E00466679 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625712FB2371982E00466679 /* Cocoa.framework */; };
 		625712FF2371982E00466679 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625712FE2371982E00466679 /* SafariExtensionHandler.swift */; };
 		625713012371982E00466679 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625713002371982E00466679 /* SafariExtensionViewController.swift */; };
@@ -108,6 +112,8 @@
 		63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS34CharacterizationTests.swift; sourceTree = "<group>"; };
 		63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS17RefreshCoalescingTests.swift; sourceTree = "<group>"; };
 		63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS10RateFallbackTests.swift; sourceTree = "<group>"; };
+		63CC34402371982E00466679 /* CCS21AtomicRenewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS21AtomicRenewTests.swift; sourceTree = "<group>"; };
+		63CC34502531982E00466679 /* AtomicRenew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicRenew.swift; sourceTree = "<group>"; };
 		625712E62371982E00466679 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		625712F62371982E00466679 /* CurrencyConverter Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CurrencyConverter Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		625712FB2371982E00466679 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -198,6 +204,7 @@
 				63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */,
 				63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */,
 				63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */,
+				63CC34402371982E00466679 /* CCS21AtomicRenewTests.swift */,
 				625712E62371982E00466679 /* Info.plist */,
 				62985BB6238464640022ED28 /* ConvertPasteboardFormatterTest.swift */,
 			);
@@ -231,6 +238,7 @@
 		6257131E23719B9800466679 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				63CC34502531982E00466679 /* AtomicRenew.swift */,
 				63CC34122531982E00466679 /* ConvertHistoryUIBeanProduction.swift */,
 				63CC34002371982E00466679 /* LegacyContractSeams.swift */,
 				6257132023719BDC00466679 /* CurrencyExchangeRate.xcdatamodeld */,
@@ -427,6 +435,8 @@
 				63CC34032371982E00466679 /* CCS34CharacterizationTests.swift in Sources */,
 				63CC34212371982E00466679 /* CCS17RefreshCoalescingTests.swift in Sources */,
 				63CC34312371982E00466679 /* CCS10RateFallbackTests.swift in Sources */,
+				63CC34412371982E00466679 /* CCS21AtomicRenewTests.swift in Sources */,
+				63CC34512531982E00466679 /* AtomicRenew.swift in Sources */,
 				6257131C23719B5300466679 /* CurrencyConverter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -446,6 +456,7 @@
 				6257132723719BDC00466679 /* CurrencyExchangeRate.xcdatamodeld in Sources */,
 				62B81E63254240C60015CC19 /* CreditCardProfile.swift in Sources */,
 				625712FF2371982E00466679 /* SafariExtensionHandler.swift in Sources */,
+				63CC34522531982E00466679 /* AtomicRenew.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -473,6 +484,7 @@
 				6285039B251B936F00E381AA /* AppDelegate.swift in Sources */,
 				62679056253F2F1F0071A9A7 /* CreditCardManagerViewModel.swift in Sources */,
 				628503A0251B936F00E381AA /* CurrencyConverter.xcdatamodeld in Sources */,
+				63CC34532531982E00466679 /* AtomicRenew.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CurrencyConverter/ConvertHistoryUIBean.swift
+++ b/CurrencyConverter/ConvertHistoryUIBean.swift
@@ -9,9 +9,15 @@
 import Foundation
 
 extension ConvertHistory: ConvertHistoryRecord {}
+extension ConvertHistory {
+    var objectIDURI: String? {
+        objectID.uriRepresentation().absoluteString
+    }
+}
 
 class ConvertHistoryDMCollection : ObservableObject {
     @Published var data : [ConvertHistoryUIBean] = []
+    @Published private(set) var lastHistoryError: RenewHistoryError?
     let dataManager: AtomicRenewStore
     let converter: RenewConverter
     private let renewWorkflow: AtomicRenewWorkflow
@@ -27,9 +33,16 @@ class ConvertHistoryDMCollection : ObservableObject {
     }
 
     private func publishReload(completion: (() -> Void)? = nil) {
-        RenewPresentationOrchestration.reload(from: dataManager) { [weak self] beans in
+        RenewPresentationOrchestration.reload(from: dataManager) { [weak self] result in
             DispatchQueue.main.async {
-                self?.data = beans
+                guard let self else { return }
+                switch result {
+                case .success(let beans):
+                    self.lastHistoryError = nil
+                    self.data = beans
+                case .failure(let error):
+                    self.lastHistoryError = .failed(error)
+                }
                 completion?()
             }
         }
@@ -54,12 +67,16 @@ class ConvertHistoryDMCollection : ObservableObject {
     @discardableResult
     func renewFx(completion: ((RenewRunResult) -> Void)? = nil) -> Bool {
         renewWorkflow.renew { [weak self] result, values in
-            guard result.accepted else {
+            guard result.accepted, let values else {
+                if let historyError = result.historyError {
+                    self?.lastHistoryError = historyError
+                }
                 completion?(result)
                 return
             }
             let beans = RenewPresentationOrchestration.beans(from: values)
             DispatchQueue.main.async {
+                self?.lastHistoryError = nil
                 self?.data = beans
                 completion?(result)
             }

--- a/CurrencyConverter/ConvertHistoryUIBean.swift
+++ b/CurrencyConverter/ConvertHistoryUIBean.swift
@@ -75,11 +75,11 @@ class ConvertHistoryDMCollection : ObservableObject {
                 return
             }
             let beans = RenewPresentationOrchestration.beans(from: values)
-            DispatchQueue.main.async {
-                self?.lastHistoryError = nil
-                self?.data = beans
-                completion?(result)
-            }
+            // AtomicRenewWorkflow completes on main and remains in-flight until this
+            // callback returns, so publish synchronously before the overlap gate opens.
+            self?.lastHistoryError = nil
+            self?.data = beans
+            completion?(result)
         }
     }
 

--- a/CurrencyConverter/ConvertHistoryUIBean.swift
+++ b/CurrencyConverter/ConvertHistoryUIBean.swift
@@ -34,7 +34,8 @@ class ConvertHistoryDMCollection : ObservableObject {
                     fxFeeRate: value.fxFee, ratio: value.ratio
                 )
                 return ConvertHistoryUIBean(
-                    id: value.id ?? UUID(), title: value.title ?? "", url: value.url ?? "",
+                    id: RenewPresentationIdentity.id(businessID: value.id, objectIDURI: value.objectID),
+                    title: value.title ?? "", url: value.url ?? "",
                     fromSymbol: value.fromSymbol ?? "", toSymbol: value.toSymbol ?? "",
                     fromAmount: value.fromAmount, fxFeeRate: normalized.fxFeeRate,
                     ratio: normalized.ratio

--- a/CurrencyConverter/ConvertHistoryUIBean.swift
+++ b/CurrencyConverter/ConvertHistoryUIBean.swift
@@ -14,12 +14,12 @@ class ConvertHistoryDMCollection : ObservableObject {
     @Published var data : [ConvertHistoryUIBean] = []
     let dataManager: AtomicRenewStore
     let converter: RenewConverter
-    private let renewCoordinator: AtomicRenewCoordinator
+    private let renewWorkflow: AtomicRenewWorkflow
 
     init(dataManager: AtomicRenewStore = CHDataManager.shared, converter: RenewConverter = CurrencyConverter.shared) {
         self.dataManager = dataManager
         self.converter = converter
-        self.renewCoordinator = AtomicRenewCoordinator(store: dataManager, converter: converter)
+        self.renewWorkflow = AtomicRenewWorkflow(store: dataManager, converter: converter)
     }
     
     @objc func reload() {
@@ -53,16 +53,14 @@ class ConvertHistoryDMCollection : ObservableObject {
     
     @discardableResult
     func renewFx(completion: ((RenewRunResult) -> Void)? = nil) -> Bool {
-        renewCoordinator.renew { [weak self] result in
+        renewWorkflow.renew { [weak self] result, values in
             guard result.accepted else {
                 completion?(result)
                 return
             }
-            guard let self else {
-                completion?(result)
-                return
-            }
-            self.publishReload {
+            let beans = RenewPresentationOrchestration.beans(from: values)
+            DispatchQueue.main.async {
+                self?.data = beans
                 completion?(result)
             }
         }

--- a/CurrencyConverter/ConvertHistoryUIBean.swift
+++ b/CurrencyConverter/ConvertHistoryUIBean.swift
@@ -27,20 +27,7 @@ class ConvertHistoryDMCollection : ObservableObject {
     }
 
     private func publishReload(completion: (() -> Void)? = nil) {
-        dataManager.readHistory { [weak self] values in
-            let beans = values.map { value in
-                let normalized = LegacyConvertHistoryCalculations.normalizedHistoryValues(
-                    fromSymbol: value.fromSymbol, toSymbol: value.toSymbol,
-                    fxFeeRate: value.fxFee, ratio: value.ratio
-                )
-                return ConvertHistoryUIBean(
-                    id: RenewPresentationIdentity.id(businessID: value.id, objectIDURI: value.objectID),
-                    title: value.title ?? "", url: value.url ?? "",
-                    fromSymbol: value.fromSymbol ?? "", toSymbol: value.toSymbol ?? "",
-                    fromAmount: value.fromAmount, fxFeeRate: normalized.fxFeeRate,
-                    ratio: normalized.ratio
-                )
-            }
+        RenewPresentationOrchestration.reload(from: dataManager) { [weak self] beans in
             DispatchQueue.main.async {
                 self?.data = beans
                 completion?()

--- a/CurrencyConverter/ConvertHistoryUIBean.swift
+++ b/CurrencyConverter/ConvertHistoryUIBean.swift
@@ -12,15 +12,38 @@ extension ConvertHistory: ConvertHistoryRecord {}
 
 class ConvertHistoryDMCollection : ObservableObject {
     @Published var data : [ConvertHistoryUIBean] = []
-    let dataManager = CHDataManager.shared
+    let dataManager: AtomicRenewStore
+    let converter: RenewConverter
+    private let renewCoordinator: AtomicRenewCoordinator
+
+    init(dataManager: AtomicRenewStore = CHDataManager.shared, converter: RenewConverter = CurrencyConverter.shared) {
+        self.dataManager = dataManager
+        self.converter = converter
+        self.renewCoordinator = AtomicRenewCoordinator(store: dataManager, converter: converter)
+    }
     
     @objc func reload() {
-        self.data = []
-        guard let cdList = dataManager.readFromCore() else {
-            return
-        }
-        for entry in cdList {
-            self.data.append(ConvertHistoryUIBean.fromCoreData(c: entry))
+        publishReload()
+    }
+
+    private func publishReload(completion: (() -> Void)? = nil) {
+        dataManager.readHistory { [weak self] values in
+            let beans = values.map { value in
+                let normalized = LegacyConvertHistoryCalculations.normalizedHistoryValues(
+                    fromSymbol: value.fromSymbol, toSymbol: value.toSymbol,
+                    fxFeeRate: value.fxFee, ratio: value.ratio
+                )
+                return ConvertHistoryUIBean(
+                    id: value.id ?? UUID(), title: value.title ?? "", url: value.url ?? "",
+                    fromSymbol: value.fromSymbol ?? "", toSymbol: value.toSymbol ?? "",
+                    fromAmount: value.fromAmount, fxFeeRate: normalized.fxFeeRate,
+                    ratio: normalized.ratio
+                )
+            }
+            DispatchQueue.main.async {
+                self?.data = beans
+                completion?()
+            }
         }
     }
     func wipe() {
@@ -40,14 +63,21 @@ class ConvertHistoryDMCollection : ObservableObject {
         
     }
     
-    func renewFx() {
-        dataManager.readFromCore()?.forEach({ (entity) in
-            CurrencyConverter.shared.convert(from: entity.fromSymbol!, to: entity.toSymbol!, unit: entity.fromAmount) { (result, error) in
-                entity.ratio = result / entity.fromAmount
+    @discardableResult
+    func renewFx(completion: ((RenewRunResult) -> Void)? = nil) -> Bool {
+        renewCoordinator.renew { [weak self] result in
+            guard result.accepted else {
+                completion?(result)
+                return
             }
-        })
-        try! sharedPersistentContainer.viewContext.save()
-        self.reload()
+            guard let self else {
+                completion?(result)
+                return
+            }
+            self.publishReload {
+                completion?(result)
+            }
+        }
     }
 
 }

--- a/CurrencyConverterTests/CCS21AtomicRenewTests.swift
+++ b/CurrencyConverterTests/CCS21AtomicRenewTests.swift
@@ -307,6 +307,36 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(store.reloadCount, 1)
     }
 
+    func testWorkflowRemainsInFlightUntilCompletionCallbackReturns() {
+        let row = RenewRowSnapshot(
+            objectID: "row", businessID: UUID(),
+            fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4
+        )
+        let store = CCS21StoreFixture(rows: [row])
+        let workflow = AtomicRenewWorkflow(store: store, converter: CCS21ConverterFixture())
+        let firstFinished = expectation(description: "first completion")
+        let overlapRejected = expectation(description: "completion-time overlap rejected")
+        var overlapWasAccepted = true
+
+        XCTAssertTrue(workflow.renew { _, _ in
+            overlapWasAccepted = workflow.renew { result, values in
+                XCTAssertFalse(result.accepted)
+                XCTAssertNil(values)
+                overlapRejected.fulfill()
+            }
+            firstFinished.fulfill()
+        })
+        wait(for: [firstFinished, overlapRejected], timeout: 1)
+        XCTAssertFalse(overlapWasAccepted)
+
+        let nextFinished = expectation(description: "next run after callback")
+        XCTAssertTrue(workflow.renew { result, _ in
+            XCTAssertTrue(result.accepted)
+            nextFinished.fulfill()
+        })
+        wait(for: [nextFinished], timeout: 1)
+    }
+
     func testMissingSnapshotConverterAndApplyCallbacksTimeoutAndIgnoreLateCallbacks() {
         let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 4)
         let scheduler = CCS21ManualRenewScheduler()
@@ -860,18 +890,13 @@ final class CCS21AtomicRenewTests: XCTestCase {
         }
     }
 
-    func testPresentationIdentityIsStableForNilBusinessIDAndPreservesBusinessID() {
-        let businessID = UUID()
+    func testPresentationIdentityIsStableAndIndependentOfBusinessID() {
         let objectID = "x-coredata://store/ConvertHistory/p1"
-        let fallbackID = RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID)
-        XCTAssertEqual(fallbackID, RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID))
+        let fallbackID = RenewPresentationIdentity.id(objectIDURI: objectID)
+        XCTAssertEqual(fallbackID, RenewPresentationIdentity.id(objectIDURI: objectID))
         XCTAssertNotEqual(
             fallbackID,
-            RenewPresentationIdentity.id(businessID: nil, objectIDURI: "x-coredata://store/ConvertHistory/p2")
-        )
-        XCTAssertEqual(
-            RenewPresentationIdentity.id(businessID: businessID, objectIDURI: objectID),
-            fallbackID
+            RenewPresentationIdentity.id(objectIDURI: "x-coredata://store/ConvertHistory/p2")
         )
         XCTAssertEqual(fallbackID.uuid.6 & 0xF0, 0x80)
         XCTAssertEqual(fallbackID.uuid.8 & 0xC0, 0x80)
@@ -903,7 +928,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
 
         XCTAssertEqual(store.reloadCount, 2)
         XCTAssertEqual(secondBeans.first?.id, firstID)
-        XCTAssertEqual(secondBeans.first?.id, RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID))
+        XCTAssertEqual(secondBeans.first?.id, RenewPresentationIdentity.id(objectIDURI: objectID))
     }
 
     func testPresentationIDDeletesExactRowEvenWhenBusinessIDsAreNil() {
@@ -934,7 +959,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let nilValues = values.filter { $0.id == nil }
         XCTAssertEqual(nilValues.count, 2)
         let deletedValue = try! XCTUnwrap(nilValues.first)
-        let deletedFallbackID = try! XCTUnwrap(beans.first { $0.id == RenewPresentationIdentity.id(businessID: nil, objectIDURI: deletedValue.objectID) }?.id)
+        let deletedFallbackID = try! XCTUnwrap(beans.first { $0.id == RenewPresentationIdentity.id(objectIDURI: deletedValue.objectID) }?.id)
         manager.wipeById(deletedFallbackID)
 
         let afterFallbackDelete = expectation(description: "fallback row deleted")
@@ -949,9 +974,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(remainingAfterFallback.filter { $0.id == nil }.count, 1)
 
         let businessValue = try! XCTUnwrap(values.first { $0.id == businessID })
-        let businessPresentationID = RenewPresentationIdentity.id(
-            businessID: businessValue.id, objectIDURI: businessValue.objectID
-        )
+        let businessPresentationID = RenewPresentationIdentity.id(objectIDURI: businessValue.objectID)
         manager.wipeById(businessPresentationID)
         let afterBusinessDelete = expectation(description: "business row deleted")
         var remainingAfterBusinessDelete: [RenewHistoryValue] = []
@@ -986,7 +1009,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(Set(beans.map(\.id)).count, 2)
         let deletedObjectID = values[0].objectID
         let deletedPresentationID = try! XCTUnwrap(
-            beans.first { $0.id == RenewPresentationIdentity.id(businessID: businessID, objectIDURI: deletedObjectID) }?.id
+            beans.first { $0.id == RenewPresentationIdentity.id(objectIDURI: deletedObjectID) }?.id
         )
         manager.wipeById(deletedPresentationID)
 

--- a/CurrencyConverterTests/CCS21AtomicRenewTests.swift
+++ b/CurrencyConverterTests/CCS21AtomicRenewTests.swift
@@ -169,23 +169,6 @@ final class CCS21AtomicRenewTests: XCTestCase {
         makeContainer().viewContext
     }
 
-    @discardableResult
-    private func renewAndReload(
-        coordinator: AtomicRenewCoordinator,
-        store: AtomicRenewStore,
-        completion: @escaping (RenewRunResult, [ConvertHistoryUIBean]) -> Void
-    ) -> Bool {
-        coordinator.renew { result in
-            guard result.accepted else {
-                completion(result, [])
-                return
-            }
-            RenewPresentationOrchestration.reload(from: store) { beans in
-                completion(result, beans)
-            }
-        }
-    }
-
     private func seedHistory(
         in context: NSManagedObjectContext,
         id: UUID?,
@@ -210,12 +193,12 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = RenewRowSnapshot(objectID: "row-1", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 3)
         let store = CCS21StoreFixture(rows: [row])
         let converter = CCS21ConverterFixture()
-        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
 
         let finished = expectation(description: "renew finished")
         let requestReady = expectation(description: "conversion requested")
         converter.onRequest = { requestReady.fulfill() }
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
         XCTAssertEqual(store.events, [.snapshot])
         wait(for: [requestReady], timeout: 1)
         XCTAssertEqual(converter.requestCount, 1)
@@ -232,7 +215,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let second = RenewRowSnapshot(objectID: "row-2", businessID: UUID(), fromSymbol: "JPY", toSymbol: "USD", fromAmount: 100, ratio: 4)
         let store = CCS21StoreFixture(rows: [first, second])
         let converter = CCS21ConverterFixture()
-        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
 
         let finished = expectation(description: "renew finished")
         let requestsReady = expectation(description: "conversions requested")
@@ -249,7 +232,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
             requestsReadyLock.unlock()
             requestsReady.fulfill()
         }
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
         XCTAssertEqual(store.events, [.snapshot])
         wait(for: [requestsReady], timeout: 1)
         converter.finish(from: "JPY", to: "USD", amount: 1)
@@ -271,14 +254,14 @@ final class CCS21AtomicRenewTests: XCTestCase {
         ]
         let store = CCS21StoreFixture(rows: rows)
         let converter = CCS21ConverterFixture()
-        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
         let first = expectation(description: "first renew")
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in first.fulfill() })
+        XCTAssertTrue(workflow.renew { _, _ in first.fulfill() })
         wait(for: [first], timeout: 1)
         let firstIDs = store.lastUpdates.map(\.objectID)
 
         let second = expectation(description: "second renew")
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in second.fulfill() })
+        XCTAssertTrue(workflow.renew { _, _ in second.fulfill() })
         wait(for: [second], timeout: 1)
 
         XCTAssertEqual(store.rows.count, rows.count)
@@ -299,11 +282,11 @@ final class CCS21AtomicRenewTests: XCTestCase {
         ]
         let store = CCS21StoreFixture(rows: rows)
         let converter = CCS21ConverterFixture()
-        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
         let finished = expectation(description: "renew finished")
         let requestReady = expectation(description: "failed conversion requested")
         converter.onRequest = { requestReady.fulfill() }
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
         wait(for: [requestReady], timeout: 1)
         converter.finish(0, amount: .nan, error: CCS21TestError.conversion)
         converter.finish(0, amount: 10)
@@ -315,13 +298,67 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(converter.requestCount, 1)
     }
 
+    func testZeroConvertedAmountLeavesRowUnchanged() {
+        let row = RenewRowSnapshot(objectID: "zero-result", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 9)
+        let store = CCS21StoreFixture(rows: [row])
+        let converter = CCS21ConverterFixture()
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
+        let requestReady = expectation(description: "conversion requested")
+        let finished = expectation(description: "renew finished")
+        converter.onRequest = { requestReady.fulfill() }
+
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
+        wait(for: [requestReady], timeout: 1)
+        converter.finish(0, amount: 0)
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertTrue(store.lastUpdates.isEmpty)
+        XCTAssertEqual(store.rows, [row])
+    }
+
+    func testSignInconsistentConvertedAmountLeavesRowUnchanged() {
+        let row = RenewRowSnapshot(objectID: "sign-inconsistent", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: -2, ratio: 9)
+        let store = CCS21StoreFixture(rows: [row])
+        let converter = CCS21ConverterFixture()
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
+        let requestReady = expectation(description: "conversion requested")
+        let finished = expectation(description: "renew finished")
+        converter.onRequest = { requestReady.fulfill() }
+
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
+        wait(for: [requestReady], timeout: 1)
+        converter.finish(0, amount: 10)
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertTrue(store.lastUpdates.isEmpty)
+        XCTAssertEqual(store.rows, [row])
+    }
+
+    func testNegativeSourceAndNegativeConvertedAmountProducesPositiveRatio() {
+        let row = RenewRowSnapshot(objectID: "negative-ratio", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: -2, ratio: 9)
+        let store = CCS21StoreFixture(rows: [row])
+        let converter = CCS21ConverterFixture()
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
+        let requestReady = expectation(description: "conversion requested")
+        let finished = expectation(description: "renew finished")
+        converter.onRequest = { requestReady.fulfill() }
+
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
+        wait(for: [requestReady], timeout: 1)
+        converter.finish(0, amount: -10)
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertEqual(store.lastUpdates.count, 1)
+        XCTAssertEqual(store.lastUpdates[0].ratio, 5, accuracy: 0.0001)
+    }
+
     func testSameCurrencyDoesNotCallConverterAndCallbackIsConsumedOnce() {
         let row = RenewRowSnapshot(objectID: "same", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 20, ratio: 4)
         let store = CCS21StoreFixture(rows: [row])
         let converter = CCS21ConverterFixture()
-        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
         let finished = expectation(description: "renew finished")
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
         wait(for: [finished], timeout: 1)
 
         XCTAssertEqual(converter.requestCount, 0)
@@ -333,10 +370,10 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)
         let store = CCS21StoreFixture(rows: [row])
         store.applyOutcomes = [RenewApplyOutcome(appliedCount: 0, changedCount: 0, saveError: CCS21TestError.save)]
-        let coordinator = AtomicRenewCoordinator(store: store, converter: CCS21ConverterFixture())
+        let workflow = AtomicRenewWorkflow(store: store, converter: CCS21ConverterFixture())
         let finished = expectation(description: "renew finished")
         var result: RenewRunResult?
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { renewResult, _ in
+        XCTAssertTrue(workflow.renew { renewResult, _ in
             result = renewResult
             finished.fulfill()
         })
@@ -353,16 +390,16 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 4)
         let store = CCS21StoreFixture(rows: [row])
         let converter = CCS21ConverterFixture()
-        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
         let requestReady = expectation(description: "conversion requested")
         converter.onRequest = { requestReady.fulfill() }
         let first = expectation(description: "first renew")
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in first.fulfill() })
+        XCTAssertTrue(workflow.renew { _, _ in first.fulfill() })
         wait(for: [requestReady], timeout: 1)
 
         let overlap = expectation(description: "overlap rejected")
         var overlapResult: RenewRunResult?
-        XCTAssertFalse(renewAndReload(coordinator: coordinator, store: store) { rejectedResult, _ in
+        XCTAssertFalse(workflow.renew { rejectedResult, _ in
             overlapResult = rejectedResult
             overlap.fulfill()
         })
@@ -701,14 +738,14 @@ final class CCS21AtomicRenewTests: XCTestCase {
             saveLock.unlock()
             try context.save()
         })
-        let coordinator = AtomicRenewCoordinator(store: manager, converter: CCS21ConverterFixture())
+        let workflow = AtomicRenewWorkflow(store: manager, converter: CCS21ConverterFixture())
 
         let firstRenew = expectation(description: "first renew")
         var firstResult: RenewRunResult?
         var firstBeans: [ConvertHistoryUIBean] = []
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: manager) {
-            firstResult = $0
-            firstBeans = $1
+        XCTAssertTrue(workflow.renew { result, values in
+            firstResult = result
+            firstBeans = RenewPresentationOrchestration.beans(from: values)
             firstRenew.fulfill()
         })
         wait(for: [firstRenew], timeout: 1)
@@ -719,9 +756,9 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let secondRenew = expectation(description: "second renew")
         var secondResult: RenewRunResult?
         var secondBeans: [ConvertHistoryUIBean] = []
-        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: manager) {
-            secondResult = $0
-            secondBeans = $1
+        XCTAssertTrue(workflow.renew { result, values in
+            secondResult = result
+            secondBeans = RenewPresentationOrchestration.beans(from: values)
             secondRenew.fulfill()
         })
         wait(for: [secondRenew], timeout: 1)

--- a/CurrencyConverterTests/CCS21AtomicRenewTests.swift
+++ b/CurrencyConverterTests/CCS21AtomicRenewTests.swift
@@ -22,6 +22,19 @@ private final class CCS21StoreFixture: AtomicRenewStore {
     private var storedLastUpdates: [RenewUpdate] = []
     var applyOutcomes: [RenewApplyOutcome] = []
     var reloadValues: [RenewHistoryValue] = []
+    var snapshotError: Error?
+    var reloadError: Error?
+    var duplicateSnapshotCallback = false
+    var duplicateApplyCallback = false
+    var duplicateReadCallback = false
+    var suppressSnapshotCallback = false
+    var suppressApplyCallback = false
+    var suppressReadCallback = false
+    var snapshotCompletion: ((Result<[RenewRowSnapshot], Error>) -> Void)?
+    var applyCompletion: ((RenewApplyOutcome) -> Void)?
+    var readCompletion: ((Result<[RenewHistoryValue], Error>) -> Void)?
+    var onApply: (() -> Void)?
+    var onRead: (() -> Void)?
 
     init(rows: [RenewRowSnapshot]) {
         self.storedRows = rows
@@ -68,8 +81,13 @@ private final class CCS21StoreFixture: AtomicRenewStore {
         storedSnapshotCount += 1
         storedEvents.append(.snapshot)
         let snapshot = storedRows
+        snapshotCompletion = completion
         lock.unlock()
-        completion(.success(snapshot))
+        if suppressSnapshotCallback { return }
+        let result = snapshotError.map { Result<[RenewRowSnapshot], Error>.failure($0) }
+            ?? .success(snapshot)
+        completion(result)
+        if duplicateSnapshotCallback { completion(result) }
     }
 
     func applyRenew(updates: [RenewUpdate], completion: @escaping (RenewApplyOutcome) -> Void) {
@@ -78,28 +96,44 @@ private final class CCS21StoreFixture: AtomicRenewStore {
         storedLastUpdates = updates
         storedEvents.append(.apply(updates))
         let outcome = applyOutcomes.isEmpty ? RenewApplyOutcome(appliedCount: updates.count, changedCount: updates.count, saveError: nil) : applyOutcomes.removeFirst()
+        applyCompletion = completion
         if outcome.saveError == nil {
             for update in updates {
                 if let index = storedRows.firstIndex(where: { $0.objectID == update.objectID }) {
                     let row = storedRows[index]
-                    storedRows[index] = RenewRowSnapshot(
-                        objectID: row.objectID, businessID: row.businessID,
-                        fromSymbol: row.fromSymbol, toSymbol: row.toSymbol,
-                        fromAmount: row.fromAmount, ratio: update.ratio
-                    )
+                    if row.businessID == update.businessID,
+                       row.fromSymbol == update.originalFromSymbol,
+                       row.toSymbol == update.originalToSymbol,
+                       row.fromAmount.bitPattern == update.originalFromAmountBitPattern,
+                       row.ratio.bitPattern == update.originalRatioBitPattern {
+                        storedRows[index] = RenewRowSnapshot(
+                            objectID: row.objectID, businessID: row.businessID,
+                            fromSymbol: row.fromSymbol, toSymbol: row.toSymbol,
+                            fromAmount: row.fromAmount, ratio: update.ratio
+                        )
+                    }
                 }
             }
         }
         lock.unlock()
+        onApply?()
+        if suppressApplyCallback { return }
         completion(outcome)
+        if duplicateApplyCallback { completion(outcome) }
     }
 
-    func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void) {
+    func readHistory(completion: @escaping (Result<[RenewHistoryValue], Error>) -> Void) {
         lock.lock()
         storedReloadCount += 1
         storedEvents.append(.reload)
+        readCompletion = completion
         lock.unlock()
-        completion(reloadValues)
+        onRead?()
+        if suppressReadCallback { return }
+        let result = reloadError.map { Result<[RenewHistoryValue], Error>.failure($0) }
+            ?? .success(reloadValues)
+        completion(result)
+        if duplicateReadCallback { completion(result) }
     }
 
     func wipeAll() {}
@@ -144,6 +178,45 @@ private final class CCS21ConverterFixture: RenewConverter {
         lock.lock()
         defer { lock.unlock() }
         return requests.count
+    }
+}
+
+private final class CCS21ManualRenewScheduler: AtomicRenewScheduler {
+    private final class Task: AtomicRenewScheduledTask {
+        let action: () -> Void
+        private(set) var isCancelled = false
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        func cancel() {
+            isCancelled = true
+        }
+
+        func fire() {
+            action()
+        }
+    }
+
+    private let lock = NSLock()
+    private var storedTasks: [Task] = []
+
+    @discardableResult
+    func schedule(after delay: TimeInterval, _ action: @escaping () -> Void) -> AtomicRenewScheduledTask {
+        _ = delay
+        let task = Task(action: action)
+        lock.lock()
+        storedTasks.append(task)
+        lock.unlock()
+        return task
+    }
+
+    func fire() {
+        lock.lock()
+        let task = storedTasks.first
+        lock.unlock()
+        task?.fire()
     }
 }
 
@@ -208,6 +281,146 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(store.events.count, 3)
         XCTAssertEqual(store.events[0], .snapshot)
         XCTAssertEqual(store.events[2], .reload)
+    }
+
+    func testDuplicateSnapshotApplyAndReadCallbacksSettleExactlyOnce() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        store.duplicateSnapshotCallback = true
+        store.duplicateApplyCallback = true
+        store.duplicateReadCallback = true
+        let workflow = AtomicRenewWorkflow(store: store, converter: CCS21ConverterFixture())
+        let finished = expectation(description: "renew finished")
+        var completionCount = 0
+
+        XCTAssertTrue(workflow.renew { _, values in
+            completionCount += 1
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertNotNil(values)
+            finished.fulfill()
+        })
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(store.snapshotCount, 1)
+        XCTAssertEqual(store.applyCount, 1)
+        XCTAssertEqual(store.reloadCount, 1)
+    }
+
+    func testMissingSnapshotConverterAndApplyCallbacksTimeoutAndIgnoreLateCallbacks() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 4)
+        let scheduler = CCS21ManualRenewScheduler()
+        let store = CCS21StoreFixture(rows: [row])
+        store.suppressSnapshotCallback = true
+        let converter = CCS21ConverterFixture()
+        var workflow: AtomicRenewWorkflow? = AtomicRenewWorkflow(
+            store: store, converter: converter, scheduler: scheduler
+        )
+        let snapshotFinished = expectation(description: "snapshot timeout")
+        var snapshotResult: RenewRunResult?
+        XCTAssertTrue(workflow!.renew { result, values in
+            snapshotResult = result
+            XCTAssertNil(values)
+            snapshotFinished.fulfill()
+        })
+        scheduler.fire()
+        wait(for: [snapshotFinished], timeout: 1)
+        XCTAssertEqual(snapshotResult?.timeoutError, .expired(.snapshot))
+        XCTAssertEqual(store.applyCount, 0)
+        store.snapshotCompletion?(.success([row]))
+        XCTAssertEqual(store.applyCount, 0)
+
+        let converterScheduler = CCS21ManualRenewScheduler()
+        let converterStore = CCS21StoreFixture(rows: [row])
+        let converterWorkflow = AtomicRenewWorkflow(
+            store: converterStore, converter: converter, scheduler: converterScheduler
+        )
+        let converterFinished = expectation(description: "converter timeout")
+        let converterRequested = expectation(description: "converter requested")
+        converter.onRequest = { converterRequested.fulfill() }
+        var converterResult: RenewRunResult?
+        XCTAssertTrue(converterWorkflow.renew { result, values in
+            converterResult = result
+            XCTAssertNil(values)
+            converterFinished.fulfill()
+        })
+        wait(for: [converterRequested], timeout: 1)
+        XCTAssertEqual(converter.requestCount, 1)
+        converterScheduler.fire()
+        wait(for: [converterFinished], timeout: 1)
+        XCTAssertEqual(converterResult?.timeoutError, .expired(.conversion))
+        converter.finish(0, amount: 10)
+        XCTAssertEqual(converterStore.applyCount, 0)
+
+        let applyScheduler = CCS21ManualRenewScheduler()
+        let applyStore = CCS21StoreFixture(rows: [RenewRowSnapshot(objectID: "same", businessID: nil, fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)])
+        applyStore.suppressApplyCallback = true
+        let applyWorkflow = AtomicRenewWorkflow(
+            store: applyStore, converter: CCS21ConverterFixture(), scheduler: applyScheduler
+        )
+        let applyFinished = expectation(description: "apply timeout")
+        let applyStarted = expectation(description: "apply started")
+        applyStore.onApply = { applyStarted.fulfill() }
+        var applyResult: RenewRunResult?
+        XCTAssertTrue(applyWorkflow.renew { result, values in
+            applyResult = result
+            XCTAssertNil(values)
+            applyFinished.fulfill()
+        })
+        wait(for: [applyStarted], timeout: 1)
+        XCTAssertEqual(applyStore.applyCount, 1)
+        applyScheduler.fire()
+        wait(for: [applyFinished], timeout: 1)
+        XCTAssertEqual(applyResult?.timeoutError, .expired(.apply))
+        applyStore.applyCompletion?(RenewApplyOutcome(appliedCount: 1, changedCount: 1, saveError: nil))
+        XCTAssertEqual(applyStore.reloadCount, 0)
+
+        workflow = nil
+    }
+
+    func testWorkflowRetainsOperationUntilTimeoutThenReleasesWorkflow() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: nil, fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        store.suppressSnapshotCallback = true
+        let scheduler = CCS21ManualRenewScheduler()
+        weak var weakWorkflow: AtomicRenewWorkflow?
+        var workflow: AtomicRenewWorkflow? = AtomicRenewWorkflow(
+            store: store, converter: CCS21ConverterFixture(), scheduler: scheduler
+        )
+        weakWorkflow = workflow
+        let finished = expectation(description: "retained workflow finished")
+        XCTAssertTrue(workflow!.renew { _, _ in finished.fulfill() })
+        workflow = nil
+        XCTAssertNotNil(weakWorkflow)
+        scheduler.fire()
+        wait(for: [finished], timeout: 1)
+        XCTAssertNil(weakWorkflow)
+    }
+
+    func testOverlapRemainsRejectedUntilDelayedReadSettles() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: nil, fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        store.suppressReadCallback = true
+        let readStarted = expectation(description: "read started")
+        store.onRead = { readStarted.fulfill() }
+        let workflow = AtomicRenewWorkflow(store: store, converter: CCS21ConverterFixture())
+        let firstFinished = expectation(description: "first renew")
+        XCTAssertTrue(workflow.renew { _, _ in firstFinished.fulfill() })
+        wait(for: [readStarted], timeout: 1)
+        XCTAssertEqual(store.reloadCount, 1)
+
+        let overlapFinished = expectation(description: "overlap rejected")
+        var overlapResult: RenewRunResult?
+        XCTAssertFalse(workflow.renew { result, _ in
+            overlapResult = result
+            overlapFinished.fulfill()
+        })
+        wait(for: [overlapFinished], timeout: 1)
+        XCTAssertFalse(overlapResult?.accepted ?? true)
+        XCTAssertEqual(store.snapshotCount, 1)
+
+        store.readCompletion?(.success(store.reloadValues))
+        wait(for: [firstFinished], timeout: 1)
     }
 
     func testOutOfOrderCallbacksApplyEachOriginalRowOnceAndReloadOnce() {
@@ -366,6 +579,23 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(store.lastUpdates[0].ratio, 1, accuracy: 0.0001)
     }
 
+    func testSameCurrencyZeroAndNonFiniteSourcesStillNormalizeToOneWithoutConverter() {
+        let rows = [
+            RenewRowSnapshot(objectID: "zero-same", businessID: nil, fromSymbol: "USD", toSymbol: "USD", fromAmount: 0, ratio: 7),
+            RenewRowSnapshot(objectID: "nan-same", businessID: nil, fromSymbol: "EUR", toSymbol: "EUR", fromAmount: .nan, ratio: 8),
+            RenewRowSnapshot(objectID: "infinity-same", businessID: nil, fromSymbol: "JPY", toSymbol: "JPY", fromAmount: .infinity, ratio: 9)
+        ]
+        let store = CCS21StoreFixture(rows: rows)
+        let converter = CCS21ConverterFixture()
+        let workflow = AtomicRenewWorkflow(store: store, converter: converter)
+        let finished = expectation(description: "same-currency exception finished")
+        XCTAssertTrue(workflow.renew { _, _ in finished.fulfill() })
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertEqual(converter.requestCount, 0)
+        XCTAssertEqual(store.lastUpdates.map(\.ratio), [1, 1, 1])
+    }
+
     func testSaveFailureIsReportedAndReloadStillOccursOnce() {
         let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)
         let store = CCS21StoreFixture(rows: [row])
@@ -384,6 +614,64 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(store.rows, [row])
         XCTAssertEqual(store.rows.first?.businessID, row.businessID)
         XCTAssertEqual(store.rows.first?.ratio, row.ratio)
+    }
+
+    func testReadFailureIsTypedAndNeverPublishedAsEmptyHistory() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: nil, fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        store.reloadValues = [RenewHistoryValue(
+            objectID: "persistent-row", id: nil, title: nil, url: nil,
+            fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, fxFee: 0, ratio: 4
+        )]
+        store.reloadError = CCS21TestError.save
+        let workflow = AtomicRenewWorkflow(store: store, converter: CCS21ConverterFixture())
+        let finished = expectation(description: "read failure finished")
+        var result: RenewRunResult?
+        var history: [RenewHistoryValue]?
+        XCTAssertTrue(workflow.renew { renewResult, values in
+            result = renewResult
+            history = values
+            finished.fulfill()
+        })
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertNotNil(result?.historyError)
+        XCTAssertNil(history)
+        XCTAssertNil(result?.saveError)
+        XCTAssertEqual(store.reloadCount, 1)
+
+        let reloaded = expectation(description: "ordinary reload failure")
+        var ordinaryReload: Result<[ConvertHistoryUIBean], Error>?
+        RenewPresentationOrchestration.reload(from: store) {
+            ordinaryReload = $0
+            reloaded.fulfill()
+        }
+        wait(for: [reloaded], timeout: 1)
+        if case .success = ordinaryReload {
+            XCTFail("read failure must not publish an empty successful history")
+        }
+    }
+
+    func testSnapshotFailureIsTypedAndSkipsApplyAndHistory() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: nil, fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        store.snapshotError = CCS21TestError.save
+        let workflow = AtomicRenewWorkflow(store: store, converter: CCS21ConverterFixture())
+        let finished = expectation(description: "snapshot failure finished")
+        var result: RenewRunResult?
+        var history: [RenewHistoryValue]?
+        XCTAssertTrue(workflow.renew { renewResult, values in
+            result = renewResult
+            history = values
+            finished.fulfill()
+        })
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertNotNil(result?.snapshotError)
+        XCTAssertNil(result?.saveError)
+        XCTAssertNil(history)
+        XCTAssertEqual(store.applyCount, 0)
+        XCTAssertEqual(store.reloadCount, 0)
     }
 
     func testOverlappingRenewIsRejectedWithoutSecondSnapshot() {
@@ -437,7 +725,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertNil(row.businessID)
 
         let applied = expectation(description: "apply")
-        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: nil, ratio: 2)]) { outcome in
+        manager.applyRenew(updates: [RenewUpdate(row: row, ratio: 2)]) { outcome in
             XCTAssertEqual(outcome.changedCount, 1)
             XCTAssertNil(outcome.saveError)
             applied.fulfill()
@@ -452,7 +740,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         }
 
         let repeated = expectation(description: "repeated apply")
-        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: nil, ratio: 2)]) { outcome in
+        manager.applyRenew(updates: [RenewUpdate(row: row, ratio: 2)]) { outcome in
             XCTAssertEqual(outcome.changedCount, 0)
             repeated.fulfill()
         }
@@ -460,6 +748,77 @@ final class CCS21AtomicRenewTests: XCTestCase {
         saveLock.lock()
         XCTAssertEqual(saveCalls, 1)
         saveLock.unlock()
+    }
+
+    func testRenewUpdateCapturesImmutableSourceFixture() {
+        let businessID = UUID()
+        let row = RenewRowSnapshot(
+            objectID: "object", businessID: businessID, fromSymbol: "USD", toSymbol: "TWD",
+            fromAmount: -0.0, ratio: .nan
+        )
+        let update = RenewUpdate(row: row, ratio: 2)
+
+        XCTAssertEqual(update.objectID, row.objectID)
+        XCTAssertEqual(update.businessID, businessID)
+        XCTAssertEqual(update.originalFromSymbol, row.fromSymbol)
+        XCTAssertEqual(update.originalToSymbol, row.toSymbol)
+        XCTAssertEqual(update.originalFromAmountBitPattern, row.fromAmount.bitPattern)
+        XCTAssertEqual(update.originalRatioBitPattern, row.ratio.bitPattern)
+    }
+
+    func testExternalSymbolAmountAndRatioEditsSkipOnlyStaleRows() {
+        let container = makeContainer()
+        let seedContext = container.viewContext
+        let symbolID = UUID()
+        let amountID = UUID()
+        let ratioID = UUID()
+        seedHistory(in: seedContext, id: symbolID, ratio: 4)
+        seedHistory(in: seedContext, id: amountID, ratio: 5)
+        seedHistory(in: seedContext, id: ratioID, ratio: 6)
+
+        let renewContext = container.newBackgroundContext()
+        let manager = CHDataManager(context: renewContext)
+        let snapshotFinished = expectation(description: "snapshot")
+        var rows: [RenewRowSnapshot] = []
+        manager.snapshotForRenew {
+            if case .success(let snapshot) = $0 { rows = snapshot }
+            snapshotFinished.fulfill()
+        }
+        wait(for: [snapshotFinished], timeout: 1)
+        XCTAssertEqual(rows.count, 3)
+
+        let external = container.newBackgroundContext()
+        external.performAndWait {
+            let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+            let objects = try! external.fetch(request)
+            objects.first { $0.id == symbolID }?.fromSymbol = "EUR"
+            objects.first { $0.id == amountID }?.fromAmount = 9
+            objects.first { $0.id == ratioID }?.ratio = 10
+            try! external.save()
+        }
+
+        let applied = expectation(description: "stale rows skipped")
+        manager.applyRenew(updates: rows.map { RenewUpdate(row: $0, ratio: $0.ratio + 1) }) { outcome in
+            XCTAssertEqual(outcome.appliedCount, 0)
+            XCTAssertEqual(outcome.changedCount, 0)
+            XCTAssertNil(outcome.saveError)
+            applied.fulfill()
+        }
+        wait(for: [applied], timeout: 1)
+
+        let reloaded = expectation(description: "external edits remain")
+        manager.readHistory { result in
+            guard case .success(let values) = result else {
+                XCTFail("external edits should remain readable")
+                reloaded.fulfill()
+                return
+            }
+            XCTAssertEqual(values.first { $0.id == symbolID }?.fromSymbol, "EUR")
+            XCTAssertEqual(values.first { $0.id == amountID }?.fromAmount, 9)
+            XCTAssertEqual(values.first { $0.id == ratioID }?.ratio, 10)
+            reloaded.fulfill()
+        }
+        wait(for: [reloaded], timeout: 1)
     }
 
     func testCoreDataSaveFailureRollsBackRenewRatios() {
@@ -484,7 +843,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = try! XCTUnwrap(snapshot)
 
         let applied = expectation(description: "failed apply")
-        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: id, ratio: 2)]) { outcome in
+        manager.applyRenew(updates: [RenewUpdate(row: row, ratio: 2)]) { outcome in
             XCTAssertEqual(outcome.changedCount, 0)
             XCTAssertNotNil(outcome.saveError)
             applied.fulfill()
@@ -510,7 +869,10 @@ final class CCS21AtomicRenewTests: XCTestCase {
             fallbackID,
             RenewPresentationIdentity.id(businessID: nil, objectIDURI: "x-coredata://store/ConvertHistory/p2")
         )
-        XCTAssertEqual(RenewPresentationIdentity.id(businessID: businessID, objectIDURI: objectID), businessID)
+        XCTAssertEqual(
+            RenewPresentationIdentity.id(businessID: businessID, objectIDURI: objectID),
+            fallbackID
+        )
         XCTAssertEqual(fallbackID.uuid.6 & 0xF0, 0x80)
         XCTAssertEqual(fallbackID.uuid.8 & 0xC0, 0x80)
     }
@@ -524,8 +886,8 @@ final class CCS21AtomicRenewTests: XCTestCase {
         )]
         var firstBeans: [ConvertHistoryUIBean] = []
         let firstReload = expectation(description: "first reload")
-        RenewPresentationOrchestration.reload(from: store) { beans in
-            firstBeans = beans
+        RenewPresentationOrchestration.reload(from: store) { result in
+            if case .success(let beans) = result { firstBeans = beans }
             firstReload.fulfill()
         }
         wait(for: [firstReload], timeout: 1)
@@ -533,8 +895,8 @@ final class CCS21AtomicRenewTests: XCTestCase {
 
         let secondReload = expectation(description: "second reload")
         var secondBeans: [ConvertHistoryUIBean] = []
-        RenewPresentationOrchestration.reload(from: store) { beans in
-            secondBeans = beans
+        RenewPresentationOrchestration.reload(from: store) { result in
+            if case .success(let beans) = result { secondBeans = beans }
             secondReload.fulfill()
         }
         wait(for: [secondReload], timeout: 1)
@@ -544,7 +906,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertEqual(secondBeans.first?.id, RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID))
     }
 
-    func testNilBusinessIDReloadFallbackDeletesExactRowAndBusinessIDDeleteStillWorks() {
+    func testPresentationIDDeletesExactRowEvenWhenBusinessIDsAreNil() {
         let container = makeContainer()
         let context = container.newBackgroundContext()
         let businessID = UUID()
@@ -556,10 +918,14 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let reloaded = expectation(description: "history reloaded")
         var values: [RenewHistoryValue] = []
         var beans: [ConvertHistoryUIBean] = []
-        manager.readHistory { history in
+        manager.readHistory { result in
+            guard case .success(let history) = result else {
+                reloaded.fulfill()
+                return
+            }
             values = history
             RenewPresentationOrchestration.reload(from: manager) { presented in
-                beans = presented
+                if case .success(let presented) = presented { beans = presented }
                 reloaded.fulfill()
             }
         }
@@ -573,19 +939,67 @@ final class CCS21AtomicRenewTests: XCTestCase {
 
         let afterFallbackDelete = expectation(description: "fallback row deleted")
         var remainingAfterFallback: [RenewHistoryValue] = []
-        manager.readHistory { remainingAfterFallback = $0; afterFallbackDelete.fulfill() }
+        manager.readHistory {
+            if case .success(let values) = $0 { remainingAfterFallback = values }
+            afterFallbackDelete.fulfill()
+        }
         wait(for: [afterFallbackDelete], timeout: 1)
         XCTAssertEqual(remainingAfterFallback.count, 2)
         XCTAssertFalse(remainingAfterFallback.contains { $0.objectID == deletedValue.objectID })
         XCTAssertEqual(remainingAfterFallback.filter { $0.id == nil }.count, 1)
 
-        manager.wipeById(businessID)
+        let businessValue = try! XCTUnwrap(values.first { $0.id == businessID })
+        let businessPresentationID = RenewPresentationIdentity.id(
+            businessID: businessValue.id, objectIDURI: businessValue.objectID
+        )
+        manager.wipeById(businessPresentationID)
         let afterBusinessDelete = expectation(description: "business row deleted")
         var remainingAfterBusinessDelete: [RenewHistoryValue] = []
-        manager.readHistory { remainingAfterBusinessDelete = $0; afterBusinessDelete.fulfill() }
+        manager.readHistory {
+            if case .success(let values) = $0 { remainingAfterBusinessDelete = values }
+            afterBusinessDelete.fulfill()
+        }
         wait(for: [afterBusinessDelete], timeout: 1)
         XCTAssertEqual(remainingAfterBusinessDelete.count, 1)
         XCTAssertNil(remainingAfterBusinessDelete.first?.id)
+    }
+
+    func testDuplicateBusinessUUIDsHaveDistinctPresentationIDsAndExactDeletion() {
+        let container = makeContainer()
+        let context = container.newBackgroundContext()
+        let businessID = UUID()
+        seedHistory(in: context, id: businessID, ratio: 1)
+        seedHistory(in: context, id: businessID, ratio: 2)
+        let manager = CHDataManager(context: context)
+
+        let loaded = expectation(description: "duplicate rows loaded")
+        var values: [RenewHistoryValue] = []
+        manager.readHistory { result in
+            if case .success(let resultValues) = result { values = resultValues }
+            loaded.fulfill()
+        }
+        wait(for: [loaded], timeout: 1)
+        XCTAssertEqual(values.count, 2)
+        XCTAssertEqual(Set(values.map(\.id)).count, 1)
+
+        let beans = RenewPresentationOrchestration.beans(from: values)
+        XCTAssertEqual(Set(beans.map(\.id)).count, 2)
+        let deletedObjectID = values[0].objectID
+        let deletedPresentationID = try! XCTUnwrap(
+            beans.first { $0.id == RenewPresentationIdentity.id(businessID: businessID, objectIDURI: deletedObjectID) }?.id
+        )
+        manager.wipeById(deletedPresentationID)
+
+        let remaining = expectation(description: "one duplicate remains")
+        var remainingValues: [RenewHistoryValue] = []
+        manager.readHistory { result in
+            if case .success(let resultValues) = result { remainingValues = resultValues }
+            remaining.fulfill()
+        }
+        wait(for: [remaining], timeout: 1)
+        XCTAssertEqual(remainingValues.count, 1)
+        XCTAssertEqual(remainingValues.first?.id, businessID)
+        XCTAssertNotEqual(remainingValues.first?.objectID, deletedObjectID)
     }
 
     func testSnapshotMakesUnsavedInsertedRowPermanentWithoutAssigningBusinessID() {
@@ -615,7 +1029,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         XCTAssertNil(row.businessID)
 
         let applied = expectation(description: "inserted row saved")
-        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: nil, ratio: 2)]) { outcome in
+        manager.applyRenew(updates: [RenewUpdate(row: row, ratio: 2)]) { outcome in
             XCTAssertEqual(outcome.changedCount, 1)
             XCTAssertNil(outcome.saveError)
             applied.fulfill()
@@ -660,7 +1074,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let updateRow = try! XCTUnwrap(row)
 
         let applied = expectation(description: "renew save")
-        manager.applyRenew(updates: [RenewUpdate(objectID: updateRow.objectID, businessID: renewID, ratio: 2)]) { outcome in
+        manager.applyRenew(updates: [RenewUpdate(row: updateRow, ratio: 2)]) { outcome in
             XCTAssertEqual(outcome.changedCount, 1)
             XCTAssertNil(outcome.saveError)
             applied.fulfill()
@@ -701,7 +1115,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let updateRow = try! XCTUnwrap(row)
 
         let failed = expectation(description: "renew save failure")
-        manager.applyRenew(updates: [RenewUpdate(objectID: updateRow.objectID, businessID: renewID, ratio: 2)]) { outcome in
+        manager.applyRenew(updates: [RenewUpdate(row: updateRow, ratio: 2)]) { outcome in
             XCTAssertEqual(outcome.changedCount, 0)
             XCTAssertNotNil(outcome.saveError)
             failed.fulfill()
@@ -745,19 +1159,30 @@ final class CCS21AtomicRenewTests: XCTestCase {
         var firstBeans: [ConvertHistoryUIBean] = []
         XCTAssertTrue(workflow.renew { result, values in
             firstResult = result
+            guard let values else {
+                XCTFail("successful renew should return history")
+                firstRenew.fulfill()
+                return
+            }
             firstBeans = RenewPresentationOrchestration.beans(from: values)
             firstRenew.fulfill()
         })
         wait(for: [firstRenew], timeout: 1)
         XCTAssertEqual(firstResult?.changedCount, 2)
         let firstIDs = firstBeans.map(\.id)
-        XCTAssertEqual(Set(firstIDs), Set([firstID, secondID]))
+        XCTAssertEqual(Set(firstIDs).count, 2)
+        XCTAssertNotEqual(Set(firstIDs), Set([firstID, secondID]))
 
         let secondRenew = expectation(description: "second renew")
         var secondResult: RenewRunResult?
         var secondBeans: [ConvertHistoryUIBean] = []
         XCTAssertTrue(workflow.renew { result, values in
             secondResult = result
+            guard let values else {
+                XCTFail("successful renew should return history")
+                secondRenew.fulfill()
+                return
+            }
             secondBeans = RenewPresentationOrchestration.beans(from: values)
             secondRenew.fulfill()
         })

--- a/CurrencyConverterTests/CCS21AtomicRenewTests.swift
+++ b/CurrencyConverterTests/CCS21AtomicRenewTests.swift
@@ -1,0 +1,390 @@
+import XCTest
+import CoreData
+@testable import CurrencyConverter
+
+private enum CCS21Event: Equatable {
+    case snapshot
+    case apply([RenewUpdate])
+    case reload
+}
+
+private enum CCS21TestError: Error {
+    case conversion
+    case save
+}
+
+private final class CCS21StoreFixture: AtomicRenewStore {
+    var rows: [RenewRowSnapshot]
+    private let lock = NSLock()
+    var events: [CCS21Event] = []
+    var applyOutcomes: [RenewApplyOutcome] = []
+    var reloadValues: [RenewHistoryValue] = []
+    var snapshotCount = 0
+    var applyCount = 0
+    var reloadCount = 0
+    var lastUpdates: [RenewUpdate] = []
+
+    init(rows: [RenewRowSnapshot]) {
+        self.rows = rows
+    }
+
+    func snapshotForRenew(completion: @escaping (Result<[RenewRowSnapshot], Error>) -> Void) {
+        lock.lock()
+        snapshotCount += 1
+        events.append(.snapshot)
+        lock.unlock()
+        completion(.success(rows))
+    }
+
+    func applyRenew(updates: [RenewUpdate], completion: @escaping (RenewApplyOutcome) -> Void) {
+        lock.lock()
+        applyCount += 1
+        lastUpdates = updates
+        events.append(.apply(updates))
+        for update in updates {
+            if let index = rows.firstIndex(where: { $0.objectID == update.objectID }) {
+                let row = rows[index]
+                rows[index] = RenewRowSnapshot(
+                    objectID: row.objectID, businessID: row.businessID,
+                    fromSymbol: row.fromSymbol, toSymbol: row.toSymbol,
+                    fromAmount: row.fromAmount, ratio: update.ratio
+                )
+            }
+        }
+        let outcome = applyOutcomes.isEmpty ? RenewApplyOutcome(appliedCount: updates.count, changedCount: updates.count, saveError: nil) : applyOutcomes.removeFirst()
+        lock.unlock()
+        completion(outcome)
+    }
+
+    func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void) {
+        lock.lock()
+        reloadCount += 1
+        events.append(.reload)
+        lock.unlock()
+        completion(reloadValues)
+    }
+
+    func wipeAll() {}
+    func wipeById(_ id: UUID) {}
+}
+
+private final class CCS21ConverterFixture: RenewConverter {
+    struct Request {
+        let from: String
+        let to: String
+        let unit: Float32
+        let completion: (Float32, Error?) -> Void
+    }
+
+    var requests: [Request] = []
+    private let lock = NSLock()
+    var onRequest: (() -> Void)?
+
+    func convert(from: String, to: String, unit: Float32, completionHandler: @escaping (Float32, Error?) -> Void) {
+        lock.lock()
+        requests.append(Request(from: from, to: to, unit: unit, completion: completionHandler))
+        let callback = onRequest
+        lock.unlock()
+        callback?()
+    }
+
+    func finish(_ index: Int, amount: Float32, error: Error? = nil) {
+        lock.lock()
+        let completion = requests[index].completion
+        lock.unlock()
+        completion(amount, error)
+    }
+
+    func finish(from: String, to: String, amount: Float32, error: Error? = nil) {
+        lock.lock()
+        let completion = requests.first { $0.from == from && $0.to == to }!.completion
+        lock.unlock()
+        completion(amount, error)
+    }
+
+    var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests.count
+    }
+}
+
+final class CCS21AtomicRenewTests: XCTestCase {
+    private func makeContext() -> NSManagedObjectContext {
+        let model = NSManagedObjectModel.mergedModel(from: [Bundle(for: CCS21AtomicRenewTests.self)])!
+        let container = NSPersistentContainer(name: "CurrencyExchangeRate", managedObjectModel: model)
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+        let loaded = expectation(description: "in-memory store loaded")
+        var loadError: Error?
+        container.loadPersistentStores { _, error in
+            loadError = error
+            loaded.fulfill()
+        }
+        wait(for: [loaded], timeout: 1)
+        XCTAssertNil(loadError)
+        return container.viewContext
+    }
+
+    private func seedHistory(in context: NSManagedObjectContext, id: UUID?, ratio: Float32) {
+        context.performAndWait {
+            let object = NSEntityDescription.insertNewObject(forEntityName: "ConvertHistory", into: context)
+            object.setValue(id, forKey: "id")
+            object.setValue(Date(timeIntervalSince1970: 1), forKey: "date")
+            object.setValue("USD", forKey: "fromSymbol")
+            object.setValue("TWD", forKey: "toSymbol")
+            object.setValue(Float32(2), forKey: "fromAmount")
+            object.setValue(ratio, forKey: "ratio")
+            object.setValue(Float32(0), forKey: "fxFee")
+            try! context.save()
+        }
+    }
+
+    func testLegacyOrderingCharacterizationIsRedUntilRenewIsWiredAtomically() {
+        let row = RenewRowSnapshot(objectID: "row-1", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 3)
+        let store = CCS21StoreFixture(rows: [row])
+        let converter = CCS21ConverterFixture()
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+
+        let finished = expectation(description: "renew finished")
+        let requestReady = expectation(description: "conversion requested")
+        converter.onRequest = { requestReady.fulfill() }
+        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        XCTAssertEqual(store.events, [.snapshot])
+        wait(for: [requestReady], timeout: 1)
+        XCTAssertEqual(converter.requestCount, 1)
+
+        converter.finish(0, amount: 80)
+        wait(for: [finished], timeout: 1)
+        XCTAssertEqual(store.events.count, 3)
+        XCTAssertEqual(store.events[0], .snapshot)
+        XCTAssertEqual(store.events[2], .reload)
+    }
+
+    func testOutOfOrderCallbacksApplyEachOriginalRowOnceAndReloadOnce() {
+        let first = RenewRowSnapshot(objectID: "row-1", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 3)
+        let second = RenewRowSnapshot(objectID: "row-2", businessID: UUID(), fromSymbol: "JPY", toSymbol: "USD", fromAmount: 100, ratio: 4)
+        let store = CCS21StoreFixture(rows: [first, second])
+        let converter = CCS21ConverterFixture()
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+
+        let finished = expectation(description: "renew finished")
+        let requestsReady = expectation(description: "conversions requested")
+        converter.onRequest = {
+            if converter.requestCount == 2 { requestsReady.fulfill() }
+        }
+        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        XCTAssertEqual(store.events, [.snapshot])
+        wait(for: [requestsReady], timeout: 1)
+        converter.finish(from: "JPY", to: "USD", amount: 1)
+        converter.finish(from: "USD", to: "TWD", amount: 10)
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertEqual(store.lastUpdates.map(\.objectID), [first.objectID, second.objectID])
+        XCTAssertEqual(store.lastUpdates[0].ratio, 5, accuracy: 0.0001)
+        XCTAssertEqual(store.lastUpdates[1].ratio, 0.01, accuracy: 0.0001)
+        XCTAssertEqual(store.applyCount, 1)
+        XCTAssertEqual(store.reloadCount, 1)
+        XCTAssertEqual(store.events.count, 3)
+    }
+
+    func testRepeatedRenewPreservesExactIdentitySetAndCount() {
+        let rows = [
+            RenewRowSnapshot(objectID: "row-1", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 0, ratio: 7),
+            RenewRowSnapshot(objectID: "row-2", businessID: UUID(), fromSymbol: "JPY", toSymbol: "JPY", fromAmount: 100, ratio: 8)
+        ]
+        let store = CCS21StoreFixture(rows: rows)
+        let converter = CCS21ConverterFixture()
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let first = expectation(description: "first renew")
+        XCTAssertTrue(collection.renewFx { _ in first.fulfill() })
+        wait(for: [first], timeout: 1)
+        let firstIDs = store.lastUpdates.map(\.objectID)
+
+        let second = expectation(description: "second renew")
+        XCTAssertTrue(collection.renewFx { _ in second.fulfill() })
+        wait(for: [second], timeout: 1)
+
+        XCTAssertEqual(store.rows.count, rows.count)
+        XCTAssertEqual(store.rows.map(\.objectID), rows.map(\.objectID))
+        XCTAssertEqual(store.rows.map(\.businessID), rows.map(\.businessID))
+        XCTAssertEqual(firstIDs, rows.map(\.objectID))
+        XCTAssertEqual(store.lastUpdates.map(\.objectID), rows.map(\.objectID))
+        XCTAssertEqual(store.reloadCount, 2)
+    }
+
+    func testFailureMissingSymbolZeroAndNonFiniteLeaveRowsUnchanged() {
+        let rows = [
+            RenewRowSnapshot(objectID: "same", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 0, ratio: 7),
+            RenewRowSnapshot(objectID: "failed", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 8),
+            RenewRowSnapshot(objectID: "missing", businessID: UUID(), fromSymbol: nil, toSymbol: "TWD", fromAmount: 2, ratio: 9),
+            RenewRowSnapshot(objectID: "zero", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 0, ratio: 10),
+            RenewRowSnapshot(objectID: "nan", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: .infinity, ratio: 11)
+        ]
+        let store = CCS21StoreFixture(rows: rows)
+        let converter = CCS21ConverterFixture()
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let finished = expectation(description: "renew finished")
+        let requestReady = expectation(description: "failed conversion requested")
+        converter.onRequest = { requestReady.fulfill() }
+        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        wait(for: [requestReady], timeout: 1)
+        converter.finish(0, amount: .nan, error: CCS21TestError.conversion)
+        converter.finish(0, amount: 10)
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertEqual(store.lastUpdates.count, 1)
+        XCTAssertEqual(store.lastUpdates[0].objectID, "same")
+        XCTAssertEqual(store.lastUpdates[0].ratio, 1, accuracy: 0.0001)
+        XCTAssertEqual(converter.requestCount, 1)
+    }
+
+    func testSameCurrencyDoesNotCallConverterAndCallbackIsConsumedOnce() {
+        let row = RenewRowSnapshot(objectID: "same", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 20, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        let converter = CCS21ConverterFixture()
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let finished = expectation(description: "renew finished")
+        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertEqual(converter.requestCount, 0)
+        XCTAssertEqual(store.lastUpdates.count, 1)
+        XCTAssertEqual(store.lastUpdates[0].ratio, 1, accuracy: 0.0001)
+    }
+
+    func testSaveFailureIsReportedAndReloadStillOccursOnce() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        store.applyOutcomes = [RenewApplyOutcome(appliedCount: 0, changedCount: 0, saveError: CCS21TestError.save)]
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: CCS21ConverterFixture())
+        let finished = expectation(description: "renew finished")
+        var result: RenewRunResult?
+        XCTAssertTrue(collection.renewFx {
+            result = $0
+            finished.fulfill()
+        })
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertNotNil(result?.saveError)
+        XCTAssertEqual(store.reloadCount, 1)
+        XCTAssertEqual(store.rows.count, 1)
+    }
+
+    func testOverlappingRenewIsRejectedWithoutSecondSnapshot() {
+        let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 4)
+        let store = CCS21StoreFixture(rows: [row])
+        let converter = CCS21ConverterFixture()
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let requestReady = expectation(description: "conversion requested")
+        converter.onRequest = { requestReady.fulfill() }
+        let first = expectation(description: "first renew")
+        XCTAssertTrue(collection.renewFx { _ in first.fulfill() })
+        wait(for: [requestReady], timeout: 1)
+
+        let overlap = expectation(description: "overlap rejected")
+        var overlapResult: RenewRunResult?
+        XCTAssertFalse(collection.renewFx {
+            overlapResult = $0
+            overlap.fulfill()
+        })
+        wait(for: [overlap], timeout: 1)
+        XCTAssertFalse(overlapResult?.accepted ?? true)
+        XCTAssertEqual(store.snapshotCount, 1)
+
+        converter.finish(0, amount: 10)
+        wait(for: [first], timeout: 1)
+    }
+
+    func testCoreDataSnapshotAndApplyPreserveObjectIdentityAndMissingBusinessID() {
+        let context = makeContext()
+        seedHistory(in: context, id: nil, ratio: 4)
+        var saveCalls = 0
+        let saveLock = NSLock()
+        let manager = CHDataManager(context: context, saveOperation: {
+            saveLock.lock()
+            saveCalls += 1
+            saveLock.unlock()
+            try context.save()
+        })
+        _ = manager.readFromCore()
+        context.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            XCTAssertNil(try! context.fetch(request).first?.value(forKey: "id"))
+        }
+        let snapshotted = expectation(description: "snapshot")
+        var snapshot: RenewRowSnapshot?
+        manager.snapshotForRenew {
+            if case .success(let rows) = $0 { snapshot = rows.first }
+            snapshotted.fulfill()
+        }
+        wait(for: [snapshotted], timeout: 1)
+        let row = try! XCTUnwrap(snapshot)
+        XCTAssertNil(row.businessID)
+
+        let applied = expectation(description: "apply")
+        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: nil, ratio: 2)]) { outcome in
+            XCTAssertEqual(outcome.changedCount, 1)
+            XCTAssertNil(outcome.saveError)
+            applied.fulfill()
+        }
+        wait(for: [applied], timeout: 1)
+        context.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            let objects = try! context.fetch(request)
+            XCTAssertEqual(objects.count, 1)
+            XCTAssertEqual(objects.first?.value(forKey: "ratio") as? Float32, 2)
+            XCTAssertNil(objects.first?.value(forKey: "id"))
+        }
+
+        let repeated = expectation(description: "repeated apply")
+        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: nil, ratio: 2)]) { outcome in
+            XCTAssertEqual(outcome.changedCount, 0)
+            repeated.fulfill()
+        }
+        wait(for: [repeated], timeout: 1)
+        saveLock.lock()
+        XCTAssertEqual(saveCalls, 1)
+        saveLock.unlock()
+    }
+
+    func testCoreDataSaveFailureRollsBackRenewRatios() {
+        let context = makeContext()
+        let id = UUID()
+        seedHistory(in: context, id: id, ratio: 4)
+        var saveCalls = 0
+        let saveLock = NSLock()
+        let manager = CHDataManager(context: context, saveOperation: {
+            saveLock.lock()
+            saveCalls += 1
+            saveLock.unlock()
+            throw CCS21TestError.save
+        })
+        let snapshotted = expectation(description: "snapshot")
+        var snapshot: RenewRowSnapshot?
+        manager.snapshotForRenew {
+            if case .success(let rows) = $0 { snapshot = rows.first }
+            snapshotted.fulfill()
+        }
+        wait(for: [snapshotted], timeout: 1)
+        let row = try! XCTUnwrap(snapshot)
+
+        let applied = expectation(description: "failed apply")
+        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: id, ratio: 2)]) { outcome in
+            XCTAssertEqual(outcome.changedCount, 0)
+            XCTAssertNotNil(outcome.saveError)
+            applied.fulfill()
+        }
+        wait(for: [applied], timeout: 1)
+        saveLock.lock()
+        XCTAssertEqual(saveCalls, 1)
+        saveLock.unlock()
+        context.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            let object = try! context.fetch(request).first
+            XCTAssertEqual(object?.value(forKey: "ratio") as? Float32, 4)
+            XCTAssertEqual(object?.value(forKey: "id") as? UUID, id)
+        }
+    }
+}

--- a/CurrencyConverterTests/CCS21AtomicRenewTests.swift
+++ b/CurrencyConverterTests/CCS21AtomicRenewTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import CoreData
-@testable import CurrencyConverter
 
 private enum CCS21Event: Equatable {
     case snapshot
@@ -170,13 +169,36 @@ final class CCS21AtomicRenewTests: XCTestCase {
         makeContainer().viewContext
     }
 
-    private func seedHistory(in context: NSManagedObjectContext, id: UUID?, ratio: Float32) {
+    @discardableResult
+    private func renewAndReload(
+        coordinator: AtomicRenewCoordinator,
+        store: AtomicRenewStore,
+        completion: @escaping (RenewRunResult, [ConvertHistoryUIBean]) -> Void
+    ) -> Bool {
+        coordinator.renew { result in
+            guard result.accepted else {
+                completion(result, [])
+                return
+            }
+            RenewPresentationOrchestration.reload(from: store) { beans in
+                completion(result, beans)
+            }
+        }
+    }
+
+    private func seedHistory(
+        in context: NSManagedObjectContext,
+        id: UUID?,
+        ratio: Float32,
+        fromSymbol: String = "USD",
+        toSymbol: String = "TWD"
+    ) {
         context.performAndWait {
             let object = NSEntityDescription.insertNewObject(forEntityName: "ConvertHistory", into: context)
             object.setValue(id, forKey: "id")
             object.setValue(Date(timeIntervalSince1970: 1), forKey: "date")
-            object.setValue("USD", forKey: "fromSymbol")
-            object.setValue("TWD", forKey: "toSymbol")
+            object.setValue(fromSymbol, forKey: "fromSymbol")
+            object.setValue(toSymbol, forKey: "toSymbol")
             object.setValue(Float32(2), forKey: "fromAmount")
             object.setValue(ratio, forKey: "ratio")
             object.setValue(Float32(0), forKey: "fxFee")
@@ -188,12 +210,12 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = RenewRowSnapshot(objectID: "row-1", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 3)
         let store = CCS21StoreFixture(rows: [row])
         let converter = CCS21ConverterFixture()
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
 
         let finished = expectation(description: "renew finished")
         let requestReady = expectation(description: "conversion requested")
         converter.onRequest = { requestReady.fulfill() }
-        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
         XCTAssertEqual(store.events, [.snapshot])
         wait(for: [requestReady], timeout: 1)
         XCTAssertEqual(converter.requestCount, 1)
@@ -210,14 +232,24 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let second = RenewRowSnapshot(objectID: "row-2", businessID: UUID(), fromSymbol: "JPY", toSymbol: "USD", fromAmount: 100, ratio: 4)
         let store = CCS21StoreFixture(rows: [first, second])
         let converter = CCS21ConverterFixture()
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
 
         let finished = expectation(description: "renew finished")
         let requestsReady = expectation(description: "conversions requested")
+        let requestsReadyLock = NSLock()
+        var requestsReadyFulfilled = false
         converter.onRequest = {
-            if converter.requestCount == 2 { requestsReady.fulfill() }
+            guard converter.requestCount == 2 else { return }
+            requestsReadyLock.lock()
+            guard !requestsReadyFulfilled else {
+                requestsReadyLock.unlock()
+                return
+            }
+            requestsReadyFulfilled = true
+            requestsReadyLock.unlock()
+            requestsReady.fulfill()
         }
-        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
         XCTAssertEqual(store.events, [.snapshot])
         wait(for: [requestsReady], timeout: 1)
         converter.finish(from: "JPY", to: "USD", amount: 1)
@@ -239,14 +271,14 @@ final class CCS21AtomicRenewTests: XCTestCase {
         ]
         let store = CCS21StoreFixture(rows: rows)
         let converter = CCS21ConverterFixture()
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
         let first = expectation(description: "first renew")
-        XCTAssertTrue(collection.renewFx { _ in first.fulfill() })
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in first.fulfill() })
         wait(for: [first], timeout: 1)
         let firstIDs = store.lastUpdates.map(\.objectID)
 
         let second = expectation(description: "second renew")
-        XCTAssertTrue(collection.renewFx { _ in second.fulfill() })
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in second.fulfill() })
         wait(for: [second], timeout: 1)
 
         XCTAssertEqual(store.rows.count, rows.count)
@@ -267,11 +299,11 @@ final class CCS21AtomicRenewTests: XCTestCase {
         ]
         let store = CCS21StoreFixture(rows: rows)
         let converter = CCS21ConverterFixture()
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
         let finished = expectation(description: "renew finished")
         let requestReady = expectation(description: "failed conversion requested")
         converter.onRequest = { requestReady.fulfill() }
-        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
         wait(for: [requestReady], timeout: 1)
         converter.finish(0, amount: .nan, error: CCS21TestError.conversion)
         converter.finish(0, amount: 10)
@@ -287,9 +319,9 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = RenewRowSnapshot(objectID: "same", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 20, ratio: 4)
         let store = CCS21StoreFixture(rows: [row])
         let converter = CCS21ConverterFixture()
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
         let finished = expectation(description: "renew finished")
-        XCTAssertTrue(collection.renewFx { _ in finished.fulfill() })
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in finished.fulfill() })
         wait(for: [finished], timeout: 1)
 
         XCTAssertEqual(converter.requestCount, 0)
@@ -301,11 +333,11 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "USD", fromAmount: 2, ratio: 4)
         let store = CCS21StoreFixture(rows: [row])
         store.applyOutcomes = [RenewApplyOutcome(appliedCount: 0, changedCount: 0, saveError: CCS21TestError.save)]
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: CCS21ConverterFixture())
+        let coordinator = AtomicRenewCoordinator(store: store, converter: CCS21ConverterFixture())
         let finished = expectation(description: "renew finished")
         var result: RenewRunResult?
-        XCTAssertTrue(collection.renewFx {
-            result = $0
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { renewResult, _ in
+            result = renewResult
             finished.fulfill()
         })
         wait(for: [finished], timeout: 1)
@@ -321,17 +353,17 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let row = RenewRowSnapshot(objectID: "row", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 4)
         let store = CCS21StoreFixture(rows: [row])
         let converter = CCS21ConverterFixture()
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: converter)
+        let coordinator = AtomicRenewCoordinator(store: store, converter: converter)
         let requestReady = expectation(description: "conversion requested")
         converter.onRequest = { requestReady.fulfill() }
         let first = expectation(description: "first renew")
-        XCTAssertTrue(collection.renewFx { _ in first.fulfill() })
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: store) { _, _ in first.fulfill() })
         wait(for: [requestReady], timeout: 1)
 
         let overlap = expectation(description: "overlap rejected")
         var overlapResult: RenewRunResult?
-        XCTAssertFalse(collection.renewFx {
-            overlapResult = $0
+        XCTAssertFalse(renewAndReload(coordinator: coordinator, store: store) { rejectedResult, _ in
+            overlapResult = rejectedResult
             overlap.fulfill()
         })
         wait(for: [overlap], timeout: 1)
@@ -435,15 +467,15 @@ final class CCS21AtomicRenewTests: XCTestCase {
     func testPresentationIdentityIsStableForNilBusinessIDAndPreservesBusinessID() {
         let businessID = UUID()
         let objectID = "x-coredata://store/ConvertHistory/p1"
-        XCTAssertEqual(
-            RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID),
-            RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID)
-        )
+        let fallbackID = RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID)
+        XCTAssertEqual(fallbackID, RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID))
         XCTAssertNotEqual(
-            RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID),
+            fallbackID,
             RenewPresentationIdentity.id(businessID: nil, objectIDURI: "x-coredata://store/ConvertHistory/p2")
         )
         XCTAssertEqual(RenewPresentationIdentity.id(businessID: businessID, objectIDURI: objectID), businessID)
+        XCTAssertEqual(fallbackID.uuid.6 & 0xF0, 0x80)
+        XCTAssertEqual(fallbackID.uuid.8 & 0xC0, 0x80)
     }
 
     func testRepeatedReloadOfNilBusinessIDUsesStableObjectIDPresentationID() {
@@ -453,22 +485,70 @@ final class CCS21AtomicRenewTests: XCTestCase {
             objectID: objectID, id: nil, title: nil, url: nil,
             fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, fxFee: 0, ratio: 4
         )]
-        let collection = ConvertHistoryDMCollection(dataManager: store, converter: CCS21ConverterFixture())
-
-        collection.reload()
+        var firstBeans: [ConvertHistoryUIBean] = []
         let firstReload = expectation(description: "first reload")
-        DispatchQueue.main.async { firstReload.fulfill() }
+        RenewPresentationOrchestration.reload(from: store) { beans in
+            firstBeans = beans
+            firstReload.fulfill()
+        }
         wait(for: [firstReload], timeout: 1)
-        let firstID = collection.data.first?.id
+        let firstID = firstBeans.first?.id
 
-        collection.reload()
         let secondReload = expectation(description: "second reload")
-        DispatchQueue.main.async { secondReload.fulfill() }
+        var secondBeans: [ConvertHistoryUIBean] = []
+        RenewPresentationOrchestration.reload(from: store) { beans in
+            secondBeans = beans
+            secondReload.fulfill()
+        }
         wait(for: [secondReload], timeout: 1)
 
         XCTAssertEqual(store.reloadCount, 2)
-        XCTAssertEqual(collection.data.first?.id, firstID)
-        XCTAssertEqual(collection.data.first?.id, RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID))
+        XCTAssertEqual(secondBeans.first?.id, firstID)
+        XCTAssertEqual(secondBeans.first?.id, RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID))
+    }
+
+    func testNilBusinessIDReloadFallbackDeletesExactRowAndBusinessIDDeleteStillWorks() {
+        let container = makeContainer()
+        let context = container.newBackgroundContext()
+        let businessID = UUID()
+        seedHistory(in: context, id: nil, ratio: 1)
+        seedHistory(in: context, id: nil, ratio: 2)
+        seedHistory(in: context, id: businessID, ratio: 3)
+        let manager = CHDataManager(context: context)
+
+        let reloaded = expectation(description: "history reloaded")
+        var values: [RenewHistoryValue] = []
+        var beans: [ConvertHistoryUIBean] = []
+        manager.readHistory { history in
+            values = history
+            RenewPresentationOrchestration.reload(from: manager) { presented in
+                beans = presented
+                reloaded.fulfill()
+            }
+        }
+        wait(for: [reloaded], timeout: 1)
+
+        let nilValues = values.filter { $0.id == nil }
+        XCTAssertEqual(nilValues.count, 2)
+        let deletedValue = try! XCTUnwrap(nilValues.first)
+        let deletedFallbackID = try! XCTUnwrap(beans.first { $0.id == RenewPresentationIdentity.id(businessID: nil, objectIDURI: deletedValue.objectID) }?.id)
+        manager.wipeById(deletedFallbackID)
+
+        let afterFallbackDelete = expectation(description: "fallback row deleted")
+        var remainingAfterFallback: [RenewHistoryValue] = []
+        manager.readHistory { remainingAfterFallback = $0; afterFallbackDelete.fulfill() }
+        wait(for: [afterFallbackDelete], timeout: 1)
+        XCTAssertEqual(remainingAfterFallback.count, 2)
+        XCTAssertFalse(remainingAfterFallback.contains { $0.objectID == deletedValue.objectID })
+        XCTAssertEqual(remainingAfterFallback.filter { $0.id == nil }.count, 1)
+
+        manager.wipeById(businessID)
+        let afterBusinessDelete = expectation(description: "business row deleted")
+        var remainingAfterBusinessDelete: [RenewHistoryValue] = []
+        manager.readHistory { remainingAfterBusinessDelete = $0; afterBusinessDelete.fulfill() }
+        wait(for: [afterBusinessDelete], timeout: 1)
+        XCTAssertEqual(remainingAfterBusinessDelete.count, 1)
+        XCTAssertNil(remainingAfterBusinessDelete.first?.id)
     }
 
     func testSnapshotMakesUnsavedInsertedRowPermanentWithoutAssigningBusinessID() {
@@ -611,8 +691,8 @@ final class CCS21AtomicRenewTests: XCTestCase {
         let context = container.newBackgroundContext()
         let firstID = UUID()
         let secondID = UUID()
-        seedHistory(in: context, id: firstID, ratio: 4)
-        seedHistory(in: context, id: secondID, ratio: 8)
+        seedHistory(in: context, id: firstID, ratio: 4, fromSymbol: "USD", toSymbol: "USD")
+        seedHistory(in: context, id: secondID, ratio: 8, fromSymbol: "USD", toSymbol: "USD")
         var saveCalls = 0
         let saveLock = NSLock()
         let manager = CHDataManager(context: context, saveOperation: {
@@ -621,28 +701,32 @@ final class CCS21AtomicRenewTests: XCTestCase {
             saveLock.unlock()
             try context.save()
         })
-        let collection = ConvertHistoryDMCollection(dataManager: manager, converter: CCS21ConverterFixture())
+        let coordinator = AtomicRenewCoordinator(store: manager, converter: CCS21ConverterFixture())
 
         let firstRenew = expectation(description: "first renew")
         var firstResult: RenewRunResult?
-        XCTAssertTrue(collection.renewFx {
+        var firstBeans: [ConvertHistoryUIBean] = []
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: manager) {
             firstResult = $0
+            firstBeans = $1
             firstRenew.fulfill()
         })
         wait(for: [firstRenew], timeout: 1)
         XCTAssertEqual(firstResult?.changedCount, 2)
-        let firstIDs = collection.data.map(\.id)
+        let firstIDs = firstBeans.map(\.id)
         XCTAssertEqual(Set(firstIDs), Set([firstID, secondID]))
 
         let secondRenew = expectation(description: "second renew")
         var secondResult: RenewRunResult?
-        XCTAssertTrue(collection.renewFx {
+        var secondBeans: [ConvertHistoryUIBean] = []
+        XCTAssertTrue(renewAndReload(coordinator: coordinator, store: manager) {
             secondResult = $0
+            secondBeans = $1
             secondRenew.fulfill()
         })
         wait(for: [secondRenew], timeout: 1)
         XCTAssertEqual(secondResult?.changedCount, 0)
-        XCTAssertEqual(collection.data.map(\.id), firstIDs)
+        XCTAssertEqual(secondBeans.map(\.id), firstIDs)
 
         context.performAndWait {
             let objects = try! context.fetch(NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory"))

--- a/CurrencyConverterTests/CCS21AtomicRenewTests.swift
+++ b/CurrencyConverterTests/CCS21AtomicRenewTests.swift
@@ -14,52 +14,91 @@ private enum CCS21TestError: Error {
 }
 
 private final class CCS21StoreFixture: AtomicRenewStore {
-    var rows: [RenewRowSnapshot]
     private let lock = NSLock()
-    var events: [CCS21Event] = []
+    private var storedRows: [RenewRowSnapshot]
+    private var storedEvents: [CCS21Event] = []
+    private var storedSnapshotCount = 0
+    private var storedApplyCount = 0
+    private var storedReloadCount = 0
+    private var storedLastUpdates: [RenewUpdate] = []
     var applyOutcomes: [RenewApplyOutcome] = []
     var reloadValues: [RenewHistoryValue] = []
-    var snapshotCount = 0
-    var applyCount = 0
-    var reloadCount = 0
-    var lastUpdates: [RenewUpdate] = []
 
     init(rows: [RenewRowSnapshot]) {
-        self.rows = rows
+        self.storedRows = rows
+    }
+
+    var rows: [RenewRowSnapshot] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedRows
+    }
+
+    var events: [CCS21Event] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedEvents
+    }
+
+    var snapshotCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedSnapshotCount
+    }
+
+    var applyCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedApplyCount
+    }
+
+    var reloadCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedReloadCount
+    }
+
+    var lastUpdates: [RenewUpdate] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedLastUpdates
     }
 
     func snapshotForRenew(completion: @escaping (Result<[RenewRowSnapshot], Error>) -> Void) {
         lock.lock()
-        snapshotCount += 1
-        events.append(.snapshot)
+        storedSnapshotCount += 1
+        storedEvents.append(.snapshot)
+        let snapshot = storedRows
         lock.unlock()
-        completion(.success(rows))
+        completion(.success(snapshot))
     }
 
     func applyRenew(updates: [RenewUpdate], completion: @escaping (RenewApplyOutcome) -> Void) {
         lock.lock()
-        applyCount += 1
-        lastUpdates = updates
-        events.append(.apply(updates))
-        for update in updates {
-            if let index = rows.firstIndex(where: { $0.objectID == update.objectID }) {
-                let row = rows[index]
-                rows[index] = RenewRowSnapshot(
-                    objectID: row.objectID, businessID: row.businessID,
-                    fromSymbol: row.fromSymbol, toSymbol: row.toSymbol,
-                    fromAmount: row.fromAmount, ratio: update.ratio
-                )
+        storedApplyCount += 1
+        storedLastUpdates = updates
+        storedEvents.append(.apply(updates))
+        let outcome = applyOutcomes.isEmpty ? RenewApplyOutcome(appliedCount: updates.count, changedCount: updates.count, saveError: nil) : applyOutcomes.removeFirst()
+        if outcome.saveError == nil {
+            for update in updates {
+                if let index = storedRows.firstIndex(where: { $0.objectID == update.objectID }) {
+                    let row = storedRows[index]
+                    storedRows[index] = RenewRowSnapshot(
+                        objectID: row.objectID, businessID: row.businessID,
+                        fromSymbol: row.fromSymbol, toSymbol: row.toSymbol,
+                        fromAmount: row.fromAmount, ratio: update.ratio
+                    )
+                }
             }
         }
-        let outcome = applyOutcomes.isEmpty ? RenewApplyOutcome(appliedCount: updates.count, changedCount: updates.count, saveError: nil) : applyOutcomes.removeFirst()
         lock.unlock()
         completion(outcome)
     }
 
     func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void) {
         lock.lock()
-        reloadCount += 1
-        events.append(.reload)
+        storedReloadCount += 1
+        storedEvents.append(.reload)
         lock.unlock()
         completion(reloadValues)
     }
@@ -110,7 +149,7 @@ private final class CCS21ConverterFixture: RenewConverter {
 }
 
 final class CCS21AtomicRenewTests: XCTestCase {
-    private func makeContext() -> NSManagedObjectContext {
+    private func makeContainer() -> NSPersistentContainer {
         let model = NSManagedObjectModel.mergedModel(from: [Bundle(for: CCS21AtomicRenewTests.self)])!
         let container = NSPersistentContainer(name: "CurrencyExchangeRate", managedObjectModel: model)
         let description = NSPersistentStoreDescription()
@@ -124,7 +163,11 @@ final class CCS21AtomicRenewTests: XCTestCase {
         }
         wait(for: [loaded], timeout: 1)
         XCTAssertNil(loadError)
-        return container.viewContext
+        return container
+    }
+
+    private func makeContext() -> NSManagedObjectContext {
+        makeContainer().viewContext
     }
 
     private func seedHistory(in context: NSManagedObjectContext, id: UUID?, ratio: Float32) {
@@ -141,7 +184,7 @@ final class CCS21AtomicRenewTests: XCTestCase {
         }
     }
 
-    func testLegacyOrderingCharacterizationIsRedUntilRenewIsWiredAtomically() {
+    func testRenewPublishesOneReloadAfterAtomicApply() {
         let row = RenewRowSnapshot(objectID: "row-1", businessID: UUID(), fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, ratio: 3)
         let store = CCS21StoreFixture(rows: [row])
         let converter = CCS21ConverterFixture()
@@ -269,7 +312,9 @@ final class CCS21AtomicRenewTests: XCTestCase {
 
         XCTAssertNotNil(result?.saveError)
         XCTAssertEqual(store.reloadCount, 1)
-        XCTAssertEqual(store.rows.count, 1)
+        XCTAssertEqual(store.rows, [row])
+        XCTAssertEqual(store.rows.first?.businessID, row.businessID)
+        XCTAssertEqual(store.rows.first?.ratio, row.ratio)
     }
 
     func testOverlappingRenewIsRejectedWithoutSecondSnapshot() {
@@ -308,7 +353,6 @@ final class CCS21AtomicRenewTests: XCTestCase {
             saveLock.unlock()
             try context.save()
         })
-        _ = manager.readFromCore()
         context.performAndWait {
             let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
             XCTAssertNil(try! context.fetch(request).first?.value(forKey: "id"))
@@ -386,5 +430,227 @@ final class CCS21AtomicRenewTests: XCTestCase {
             XCTAssertEqual(object?.value(forKey: "ratio") as? Float32, 4)
             XCTAssertEqual(object?.value(forKey: "id") as? UUID, id)
         }
+    }
+
+    func testPresentationIdentityIsStableForNilBusinessIDAndPreservesBusinessID() {
+        let businessID = UUID()
+        let objectID = "x-coredata://store/ConvertHistory/p1"
+        XCTAssertEqual(
+            RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID),
+            RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID)
+        )
+        XCTAssertNotEqual(
+            RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID),
+            RenewPresentationIdentity.id(businessID: nil, objectIDURI: "x-coredata://store/ConvertHistory/p2")
+        )
+        XCTAssertEqual(RenewPresentationIdentity.id(businessID: businessID, objectIDURI: objectID), businessID)
+    }
+
+    func testRepeatedReloadOfNilBusinessIDUsesStableObjectIDPresentationID() {
+        let objectID = "x-coredata://store/ConvertHistory/p1"
+        let store = CCS21StoreFixture(rows: [])
+        store.reloadValues = [RenewHistoryValue(
+            objectID: objectID, id: nil, title: nil, url: nil,
+            fromSymbol: "USD", toSymbol: "TWD", fromAmount: 2, fxFee: 0, ratio: 4
+        )]
+        let collection = ConvertHistoryDMCollection(dataManager: store, converter: CCS21ConverterFixture())
+
+        collection.reload()
+        let firstReload = expectation(description: "first reload")
+        DispatchQueue.main.async { firstReload.fulfill() }
+        wait(for: [firstReload], timeout: 1)
+        let firstID = collection.data.first?.id
+
+        collection.reload()
+        let secondReload = expectation(description: "second reload")
+        DispatchQueue.main.async { secondReload.fulfill() }
+        wait(for: [secondReload], timeout: 1)
+
+        XCTAssertEqual(store.reloadCount, 2)
+        XCTAssertEqual(collection.data.first?.id, firstID)
+        XCTAssertEqual(collection.data.first?.id, RenewPresentationIdentity.id(businessID: nil, objectIDURI: objectID))
+    }
+
+    func testSnapshotMakesUnsavedInsertedRowPermanentWithoutAssigningBusinessID() {
+        let container = makeContainer()
+        let context = container.newBackgroundContext()
+        context.performAndWait {
+            let object = NSEntityDescription.insertNewObject(forEntityName: "ConvertHistory", into: context)
+            object.setValue(nil, forKey: "id")
+            object.setValue(Date(timeIntervalSince1970: 1), forKey: "date")
+            object.setValue("USD", forKey: "fromSymbol")
+            object.setValue("TWD", forKey: "toSymbol")
+            object.setValue(Float32(2), forKey: "fromAmount")
+            object.setValue(Float32(4), forKey: "ratio")
+            object.setValue(Float32(0), forKey: "fxFee")
+            XCTAssertTrue(object.objectID.isTemporaryID)
+        }
+        let manager = CHDataManager(context: context)
+
+        let firstSnapshot = expectation(description: "permanent snapshot")
+        var firstRow: RenewRowSnapshot?
+        manager.snapshotForRenew {
+            if case .success(let rows) = $0 { firstRow = rows.first }
+            firstSnapshot.fulfill()
+        }
+        wait(for: [firstSnapshot], timeout: 1)
+        let row = try! XCTUnwrap(firstRow)
+        XCTAssertNil(row.businessID)
+
+        let applied = expectation(description: "inserted row saved")
+        manager.applyRenew(updates: [RenewUpdate(objectID: row.objectID, businessID: nil, ratio: 2)]) { outcome in
+            XCTAssertEqual(outcome.changedCount, 1)
+            XCTAssertNil(outcome.saveError)
+            applied.fulfill()
+        }
+        wait(for: [applied], timeout: 1)
+
+        let secondSnapshot = expectation(description: "saved snapshot")
+        var secondRow: RenewRowSnapshot?
+        manager.snapshotForRenew {
+            if case .success(let rows) = $0 { secondRow = rows.first }
+            secondSnapshot.fulfill()
+        }
+        wait(for: [secondSnapshot], timeout: 1)
+        XCTAssertEqual(secondRow?.objectID, row.objectID)
+        XCTAssertNil(secondRow?.businessID)
+        XCTAssertEqual(secondRow?.ratio, 2)
+    }
+
+    func testDedicatedRenewSaveLeavesUnrelatedViewContextEditPending() {
+        let container = makeContainer()
+        let viewContext = container.viewContext
+        let renewID = UUID()
+        let unrelatedID = UUID()
+        seedHistory(in: viewContext, id: renewID, ratio: 4)
+        seedHistory(in: viewContext, id: unrelatedID, ratio: 8)
+        viewContext.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            request.predicate = NSPredicate(format: "id == %@", unrelatedID as CVarArg)
+            try! viewContext.fetch(request).first!.setValue("pending", forKey: "title")
+            XCTAssertTrue(viewContext.hasChanges)
+        }
+
+        let renewContext = container.newBackgroundContext()
+        let manager = CHDataManager(context: renewContext)
+        let snapshot = expectation(description: "snapshot")
+        var row: RenewRowSnapshot?
+        manager.snapshotForRenew {
+            if case .success(let rows) = $0 { row = rows.first(where: { $0.businessID == renewID }) }
+            snapshot.fulfill()
+        }
+        wait(for: [snapshot], timeout: 1)
+        let updateRow = try! XCTUnwrap(row)
+
+        let applied = expectation(description: "renew save")
+        manager.applyRenew(updates: [RenewUpdate(objectID: updateRow.objectID, businessID: renewID, ratio: 2)]) { outcome in
+            XCTAssertEqual(outcome.changedCount, 1)
+            XCTAssertNil(outcome.saveError)
+            applied.fulfill()
+        }
+        wait(for: [applied], timeout: 1)
+
+        viewContext.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            request.predicate = NSPredicate(format: "id == %@", unrelatedID as CVarArg)
+            let object = try! viewContext.fetch(request).first
+            XCTAssertEqual(object?.value(forKey: "title") as? String, "pending")
+            XCTAssertTrue(viewContext.hasChanges)
+        }
+    }
+
+    func testDedicatedRenewSaveFailureLeavesUnrelatedViewContextEditPending() {
+        let container = makeContainer()
+        let viewContext = container.viewContext
+        let renewID = UUID()
+        let unrelatedID = UUID()
+        seedHistory(in: viewContext, id: renewID, ratio: 4)
+        seedHistory(in: viewContext, id: unrelatedID, ratio: 8)
+        viewContext.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            request.predicate = NSPredicate(format: "id == %@", unrelatedID as CVarArg)
+            try! viewContext.fetch(request).first!.setValue("pending", forKey: "title")
+        }
+
+        let renewContext = container.newBackgroundContext()
+        let manager = CHDataManager(context: renewContext, saveOperation: { throw CCS21TestError.save })
+        let snapshot = expectation(description: "snapshot")
+        var row: RenewRowSnapshot?
+        manager.snapshotForRenew {
+            if case .success(let rows) = $0 { row = rows.first(where: { $0.businessID == renewID }) }
+            snapshot.fulfill()
+        }
+        wait(for: [snapshot], timeout: 1)
+        let updateRow = try! XCTUnwrap(row)
+
+        let failed = expectation(description: "renew save failure")
+        manager.applyRenew(updates: [RenewUpdate(objectID: updateRow.objectID, businessID: renewID, ratio: 2)]) { outcome in
+            XCTAssertEqual(outcome.changedCount, 0)
+            XCTAssertNotNil(outcome.saveError)
+            failed.fulfill()
+        }
+        wait(for: [failed], timeout: 1)
+
+        renewContext.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            request.predicate = NSPredicate(format: "id == %@", renewID as CVarArg)
+            let object = try! renewContext.fetch(request).first
+            XCTAssertEqual(object?.value(forKey: "ratio") as? Float32, 4)
+        }
+        viewContext.performAndWait {
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
+            request.predicate = NSPredicate(format: "id == %@", unrelatedID as CVarArg)
+            let object = try! viewContext.fetch(request).first
+            XCTAssertEqual(object?.value(forKey: "title") as? String, "pending")
+            XCTAssertTrue(viewContext.hasChanges)
+        }
+    }
+
+    func testCoreDataRepeatedRenewPreservesIdentityCountAndSavesOnlyChangedRatios() {
+        let container = makeContainer()
+        let context = container.newBackgroundContext()
+        let firstID = UUID()
+        let secondID = UUID()
+        seedHistory(in: context, id: firstID, ratio: 4)
+        seedHistory(in: context, id: secondID, ratio: 8)
+        var saveCalls = 0
+        let saveLock = NSLock()
+        let manager = CHDataManager(context: context, saveOperation: {
+            saveLock.lock()
+            saveCalls += 1
+            saveLock.unlock()
+            try context.save()
+        })
+        let collection = ConvertHistoryDMCollection(dataManager: manager, converter: CCS21ConverterFixture())
+
+        let firstRenew = expectation(description: "first renew")
+        var firstResult: RenewRunResult?
+        XCTAssertTrue(collection.renewFx {
+            firstResult = $0
+            firstRenew.fulfill()
+        })
+        wait(for: [firstRenew], timeout: 1)
+        XCTAssertEqual(firstResult?.changedCount, 2)
+        let firstIDs = collection.data.map(\.id)
+        XCTAssertEqual(Set(firstIDs), Set([firstID, secondID]))
+
+        let secondRenew = expectation(description: "second renew")
+        var secondResult: RenewRunResult?
+        XCTAssertTrue(collection.renewFx {
+            secondResult = $0
+            secondRenew.fulfill()
+        })
+        wait(for: [secondRenew], timeout: 1)
+        XCTAssertEqual(secondResult?.changedCount, 0)
+        XCTAssertEqual(collection.data.map(\.id), firstIDs)
+
+        context.performAndWait {
+            let objects = try! context.fetch(NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory"))
+            XCTAssertEqual(objects.count, 2)
+            XCTAssertEqual(Set(objects.compactMap { $0.value(forKey: "id") as? UUID }), Set([firstID, secondID]))
+        }
+        saveLock.lock()
+        XCTAssertEqual(saveCalls, 1)
+        saveLock.unlock()
     }
 }

--- a/Scripts/verify-ccs21-standalone.sh
+++ b/Scripts/verify-ccs21-standalone.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+root_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+project_file="$root_dir/CurrencyConverter.xcodeproj/project.pbxproj"
+tests_file="$root_dir/CurrencyConverterTests/CCS21AtomicRenewTests.swift"
+
+debug_settings=$(awk '
+    /625713152371982E00466679 \/\* Debug \*\// { capture = 1 }
+    capture { print }
+    capture && /name = Debug;/ { exit }
+' "$project_file")
+release_settings=$(awk '
+    /625713162371982E00466679 \/\* Release \*\// { capture = 1 }
+    capture { print }
+    capture && /name = Release;/ { exit }
+' "$project_file")
+
+case "$debug_settings $release_settings" in
+    *BUNDLE_LOADER*|*TEST_HOST*)
+        echo "CurrencyConverterTests must not define TEST_HOST or BUNDLE_LOADER" >&2
+        exit 1
+        ;;
+esac
+
+test_sources=$(awk '
+    /625712DC2371982E00466679 \/\* Sources \*\/ = \{/ { capture = 1 }
+    capture { print }
+    capture && /runOnlyForDeploymentPostprocessing = 0;/ { exit }
+' "$project_file")
+
+printf '%s\n' "$test_sources" | grep -Fq '62C49F25252AA14600ED2E72 /* CHDataManager.swift in Sources */'
+printf '%s\n' "$test_sources" | grep -Fq '63CC34512531982E00466679 /* AtomicRenew.swift in Sources */'
+grep -Fq '63CC34522531982E00466679 /* AtomicRenew.swift in Sources */' "$project_file"
+grep -Fq '63CC34532531982E00466679 /* AtomicRenew.swift in Sources */' "$project_file"
+grep -Fq '62C49F26252AA14600ED2E72 /* CHDataManager.swift in Sources */' "$project_file"
+grep -Fq '62C49F27252AA14600ED2E72 /* CHDataManager.swift in Sources */' "$project_file"
+
+if grep -Fq 'ConvertHistoryDMCollection' "$tests_file"; then
+    echo "CCS21 tests must not reference the SwiftUI app collection" >&2
+    exit 1
+fi
+grep -Fq 'RenewPresentationOrchestration.reload' "$tests_file"
+grep -Fq 'RenewPresentationOrchestration.reload' "$root_dir/CurrencyConverter/ConvertHistoryUIBean.swift"
+
+echo "CCS21 standalone architecture checks passed"

--- a/Scripts/verify-ccs21-standalone.sh
+++ b/Scripts/verify-ccs21-standalone.sh
@@ -40,7 +40,22 @@ if grep -Fq 'ConvertHistoryDMCollection' "$tests_file"; then
     echo "CCS21 tests must not reference the SwiftUI app collection" >&2
     exit 1
 fi
-grep -Fq 'RenewPresentationOrchestration.reload' "$tests_file"
+grep -Fq 'AtomicRenewWorkflow' "$tests_file"
+grep -Fq 'AtomicRenewWorkflow' "$root_dir/CurrencyConverter/ConvertHistoryUIBean.swift"
+if grep -Fq 'ConvertHistoryUIBean' "$root_dir/Shared/AtomicRenew.swift"; then
+    echo "AtomicRenew.swift must not depend on UI beans" >&2
+    exit 1
+fi
+if grep -Fq 'AtomicRenewCoordinator' "$tests_file"; then
+    echo "CCS21 tests must instantiate AtomicRenewWorkflow, not its coordinator" >&2
+    exit 1
+fi
+if grep -Fq 'renewAndReload' "$tests_file"; then
+    echo "CCS21 tests must not shadow the production renew workflow" >&2
+    exit 1
+fi
+grep -Fq 'RenewPresentationOrchestration.beans(from:' "$tests_file"
+grep -Fq 'RenewPresentationOrchestration.beans(from:' "$root_dir/CurrencyConverter/ConvertHistoryUIBean.swift"
 grep -Fq 'RenewPresentationOrchestration.reload' "$root_dir/CurrencyConverter/ConvertHistoryUIBean.swift"
 
 echo "CCS21 standalone architecture checks passed"

--- a/Shared/AtomicRenew.swift
+++ b/Shared/AtomicRenew.swift
@@ -46,31 +46,6 @@ struct RenewHistoryValue {
     let ratio: Float32
 }
 
-struct ConvertHistoryUIBean: Identifiable {
-    var id: UUID
-    var title: String?
-    var url: String
-    var fromSymbol: String
-    var toSymbol: String
-    var fromAmount: Float
-
-    var toAmount: Float {
-        LegacyConvertHistoryCalculations.toAmount(fromAmount: fromAmount, ratio: ratio)
-    }
-
-    var fxFee: Float {
-        LegacyConvertHistoryCalculations.fxFee(toAmount: toAmount, fxFeeRate: fxFeeRate)
-    }
-
-    var toAmountWithFx: Float {
-        LegacyConvertHistoryCalculations.toAmountWithFx(toAmount: toAmount, fxFeeRate: fxFeeRate)
-    }
-
-    var fxFeeRate: Float
-    var ratio: Float
-    var isChecked = false
-}
-
 struct RenewApplyOutcome {
     let appliedCount: Int
     let changedCount: Int
@@ -103,27 +78,53 @@ protocol RenewConverter: AnyObject {
     func convert(from: String, to: String, unit: Float32, completionHandler: @escaping (Float32, Error?) -> Void)
 }
 
-enum RenewPresentationOrchestration {
-    static func reload(from store: AtomicRenewStore, completion: @escaping ([ConvertHistoryUIBean]) -> Void) {
-        store.readHistory { values in
-            completion(values.map { value in
-                let normalized = LegacyConvertHistoryCalculations.normalizedHistoryValues(
-                    fromSymbol: value.fromSymbol, toSymbol: value.toSymbol,
-                    fxFeeRate: value.fxFee, ratio: value.ratio
-                )
-                return ConvertHistoryUIBean(
-                    id: RenewPresentationIdentity.id(businessID: value.id, objectIDURI: value.objectID),
-                    title: value.title ?? "", url: value.url ?? "",
-                    fromSymbol: value.fromSymbol ?? "", toSymbol: value.toSymbol ?? "",
-                    fromAmount: value.fromAmount, fxFeeRate: normalized.fxFeeRate,
-                    ratio: normalized.ratio
-                )
-            })
+extension CurrencyConverter: RenewConverter {}
+
+private final class AtomicRenewCompletionGate {
+    private let lock = NSLock()
+    private var didComplete = false
+
+    func complete(
+        result: RenewRunResult,
+        history: [RenewHistoryValue],
+        completion: @escaping (RenewRunResult, [RenewHistoryValue]) -> Void
+    ) {
+        lock.lock()
+        guard !didComplete else {
+            lock.unlock()
+            return
+        }
+        didComplete = true
+        lock.unlock()
+        DispatchQueue.main.async {
+            completion(result, history)
         }
     }
 }
 
-extension CurrencyConverter: RenewConverter {}
+final class AtomicRenewWorkflow {
+    private let store: AtomicRenewStore
+    private let coordinator: AtomicRenewCoordinator
+
+    init(store: AtomicRenewStore, converter: RenewConverter) {
+        self.store = store
+        self.coordinator = AtomicRenewCoordinator(store: store, converter: converter)
+    }
+
+    @discardableResult
+    func renew(completion: @escaping (RenewRunResult, [RenewHistoryValue]) -> Void) -> Bool {
+        let completionGate = AtomicRenewCompletionGate()
+        return coordinator.renew { [store] result in
+            guard result.accepted else {
+                completionGate.complete(result: result, history: [], completion: completion)
+                return
+            }
+            store.readHistory { values in
+                completionGate.complete(result: result, history: values, completion: completion)
+            }
+        }
+    }
+}
 
 final class AtomicRenewCoordinator {
     private let store: AtomicRenewStore
@@ -208,7 +209,7 @@ final class AtomicRenewCoordinator {
                         return
                     }
                     let ratio = amount / row.fromAmount
-                    complete(ratio.isFinite ? ratio : nil)
+                    complete(ratio.isFinite && ratio > 0 ? ratio : nil)
                 }
             }
         }

--- a/Shared/AtomicRenew.swift
+++ b/Shared/AtomicRenew.swift
@@ -1,4 +1,22 @@
 import Foundation
+import CryptoKit
+
+enum RenewPresentationIdentity {
+    static func id(businessID: UUID?, objectIDURI: String) -> UUID {
+        if let businessID {
+            return businessID
+        }
+
+        var bytes = Array(SHA256.hash(data: Data(objectIDURI.utf8)))
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
+            bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+}
 
 struct RenewRowSnapshot: Equatable {
     let objectID: String
@@ -16,6 +34,7 @@ struct RenewUpdate: Equatable {
 }
 
 struct RenewHistoryValue {
+    let objectID: String
     let id: UUID?
     let title: String?
     let url: String?

--- a/Shared/AtomicRenew.swift
+++ b/Shared/AtomicRenew.swift
@@ -8,7 +8,8 @@ enum RenewPresentationIdentity {
         }
 
         var bytes = Array(SHA256.hash(data: Data(objectIDURI.utf8)))
-        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        // This is a deterministic SHA-256 construction, not RFC 4122 UUIDv5.
+        bytes[6] = (bytes[6] & 0x0F) | 0x80
         bytes[8] = (bytes[8] & 0x3F) | 0x80
         return UUID(uuid: (
             bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
@@ -45,6 +46,31 @@ struct RenewHistoryValue {
     let ratio: Float32
 }
 
+struct ConvertHistoryUIBean: Identifiable {
+    var id: UUID
+    var title: String?
+    var url: String
+    var fromSymbol: String
+    var toSymbol: String
+    var fromAmount: Float
+
+    var toAmount: Float {
+        LegacyConvertHistoryCalculations.toAmount(fromAmount: fromAmount, ratio: ratio)
+    }
+
+    var fxFee: Float {
+        LegacyConvertHistoryCalculations.fxFee(toAmount: toAmount, fxFeeRate: fxFeeRate)
+    }
+
+    var toAmountWithFx: Float {
+        LegacyConvertHistoryCalculations.toAmountWithFx(toAmount: toAmount, fxFeeRate: fxFeeRate)
+    }
+
+    var fxFeeRate: Float
+    var ratio: Float
+    var isChecked = false
+}
+
 struct RenewApplyOutcome {
     let appliedCount: Int
     let changedCount: Int
@@ -75,6 +101,26 @@ protocol AtomicRenewStore: AnyObject {
 
 protocol RenewConverter: AnyObject {
     func convert(from: String, to: String, unit: Float32, completionHandler: @escaping (Float32, Error?) -> Void)
+}
+
+enum RenewPresentationOrchestration {
+    static func reload(from store: AtomicRenewStore, completion: @escaping ([ConvertHistoryUIBean]) -> Void) {
+        store.readHistory { values in
+            completion(values.map { value in
+                let normalized = LegacyConvertHistoryCalculations.normalizedHistoryValues(
+                    fromSymbol: value.fromSymbol, toSymbol: value.toSymbol,
+                    fxFeeRate: value.fxFee, ratio: value.ratio
+                )
+                return ConvertHistoryUIBean(
+                    id: RenewPresentationIdentity.id(businessID: value.id, objectIDURI: value.objectID),
+                    title: value.title ?? "", url: value.url ?? "",
+                    fromSymbol: value.fromSymbol ?? "", toSymbol: value.toSymbol ?? "",
+                    fromAmount: value.fromAmount, fxFeeRate: normalized.fxFeeRate,
+                    ratio: normalized.ratio
+                )
+            })
+        }
+    }
 }
 
 extension CurrencyConverter: RenewConverter {}

--- a/Shared/AtomicRenew.swift
+++ b/Shared/AtomicRenew.swift
@@ -3,10 +3,7 @@ import CryptoKit
 
 enum RenewPresentationIdentity {
     static func id(businessID: UUID?, objectIDURI: String) -> UUID {
-        if let businessID {
-            return businessID
-        }
-
+        _ = businessID
         var bytes = Array(SHA256.hash(data: Data(objectIDURI.utf8)))
         // This is a deterministic SHA-256 construction, not RFC 4122 UUIDv5.
         bytes[6] = (bytes[6] & 0x0F) | 0x80
@@ -31,7 +28,21 @@ struct RenewRowSnapshot: Equatable {
 struct RenewUpdate: Equatable {
     let objectID: String
     let businessID: UUID?
+    let originalFromSymbol: String?
+    let originalToSymbol: String?
+    let originalFromAmountBitPattern: UInt32
+    let originalRatioBitPattern: UInt32
     let ratio: Float32
+
+    init(row: RenewRowSnapshot, ratio: Float32) {
+        objectID = row.objectID
+        businessID = row.businessID
+        originalFromSymbol = row.fromSymbol
+        originalToSymbol = row.toSymbol
+        originalFromAmountBitPattern = row.fromAmount.bitPattern
+        originalRatioBitPattern = row.ratio.bitPattern
+        self.ratio = ratio
+    }
 }
 
 struct RenewHistoryValue {
@@ -52,24 +63,69 @@ struct RenewApplyOutcome {
     let saveError: Error?
 }
 
+enum RenewTimeoutStage: Equatable {
+    case snapshot
+    case conversion
+    case apply
+    case history
+}
+
+enum RenewSnapshotError: Error {
+    case failed(Error)
+
+    var underlyingError: Error {
+        switch self {
+        case .failed(let error): return error
+        }
+    }
+}
+
+enum RenewTimeoutError: Error, Equatable {
+    case expired(RenewTimeoutStage)
+}
+
+enum RenewSaveError: Error {
+    case failed(Error)
+
+    var underlyingError: Error {
+        switch self {
+        case .failed(let error): return error
+        }
+    }
+}
+
+enum RenewHistoryError: Error {
+    case failed(Error)
+
+    var underlyingError: Error {
+        switch self {
+        case .failed(let error): return error
+        }
+    }
+}
+
 struct RenewRunResult {
     let accepted: Bool
     let requestedCount: Int
     let successfulCalculationCount: Int
     let appliedCount: Int
     let changedCount: Int
-    let saveError: Error?
+    let snapshotError: RenewSnapshotError?
+    let timeoutError: RenewTimeoutError?
+    let saveError: RenewSaveError?
+    let historyError: RenewHistoryError?
 
     static let rejected = RenewRunResult(
         accepted: false, requestedCount: 0, successfulCalculationCount: 0,
-        appliedCount: 0, changedCount: 0, saveError: nil
+        appliedCount: 0, changedCount: 0, snapshotError: nil,
+        timeoutError: nil, saveError: nil, historyError: nil
     )
 }
 
 protocol AtomicRenewStore: AnyObject {
     func snapshotForRenew(completion: @escaping (Result<[RenewRowSnapshot], Error>) -> Void)
     func applyRenew(updates: [RenewUpdate], completion: @escaping (RenewApplyOutcome) -> Void)
-    func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void)
+    func readHistory(completion: @escaping (Result<[RenewHistoryValue], Error>) -> Void)
     func wipeAll()
     func wipeById(_ id: UUID)
 }
@@ -80,120 +136,204 @@ protocol RenewConverter: AnyObject {
 
 extension CurrencyConverter: RenewConverter {}
 
-private final class AtomicRenewCompletionGate {
-    private let lock = NSLock()
-    private var didComplete = false
+protocol AtomicRenewScheduledTask: AnyObject {
+    func cancel()
+}
 
-    func complete(
-        result: RenewRunResult,
-        history: [RenewHistoryValue],
-        completion: @escaping (RenewRunResult, [RenewHistoryValue]) -> Void
-    ) {
+protocol AtomicRenewScheduler: AnyObject {
+    @discardableResult
+    func schedule(after delay: TimeInterval, _ action: @escaping () -> Void) -> AtomicRenewScheduledTask
+}
+
+private final class DispatchRenewScheduledTask: AtomicRenewScheduledTask {
+    private let item: DispatchWorkItem
+
+    init(item: DispatchWorkItem) {
+        self.item = item
+    }
+
+    func cancel() {
+        item.cancel()
+    }
+}
+
+private final class DispatchRenewScheduler: AtomicRenewScheduler {
+    @discardableResult
+    func schedule(after delay: TimeInterval, _ action: @escaping () -> Void) -> AtomicRenewScheduledTask {
+        let item = DispatchWorkItem(block: action)
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay, execute: item)
+        return DispatchRenewScheduledTask(item: item)
+    }
+}
+
+private final class RenewOneShot<Value> {
+    private let lock = NSLock()
+    private var didConsume = false
+
+    func consume(_ value: Value, action: (Value) -> Void) {
         lock.lock()
-        guard !didComplete else {
+        guard !didConsume else {
             lock.unlock()
             return
         }
-        didComplete = true
+        didConsume = true
         lock.unlock()
-        DispatchQueue.main.async {
-            completion(result, history)
-        }
+        action(value)
     }
 }
 
 final class AtomicRenewWorkflow {
-    private let store: AtomicRenewStore
-    private let coordinator: AtomicRenewCoordinator
-
-    init(store: AtomicRenewStore, converter: RenewConverter) {
-        self.store = store
-        self.coordinator = AtomicRenewCoordinator(store: store, converter: converter)
-    }
-
-    @discardableResult
-    func renew(completion: @escaping (RenewRunResult, [RenewHistoryValue]) -> Void) -> Bool {
-        let completionGate = AtomicRenewCompletionGate()
-        return coordinator.renew { [store] result in
-            guard result.accepted else {
-                completionGate.complete(result: result, history: [], completion: completion)
-                return
-            }
-            store.readHistory { values in
-                completionGate.complete(result: result, history: values, completion: completion)
-            }
-        }
-    }
-}
-
-final class AtomicRenewCoordinator {
+    private let stateLock = NSLock()
     private let store: AtomicRenewStore
     private let converter: RenewConverter
-    private let stateLock = NSLock()
-    private let calculationQueue = DispatchQueue(label: "CurrencyConverter.atomic-renew.calculations", attributes: .concurrent)
-    private var isInFlight = false
+    private let timeout: TimeInterval
+    private let scheduler: AtomicRenewScheduler
+    private var activeOperation: AtomicRenewOperation?
 
-    init(store: AtomicRenewStore, converter: RenewConverter) {
+    init(
+        store: AtomicRenewStore,
+        converter: RenewConverter,
+        timeout: TimeInterval = 30,
+        scheduler: AtomicRenewScheduler = DispatchRenewScheduler()
+    ) {
         self.store = store
         self.converter = converter
+        self.timeout = timeout
+        self.scheduler = scheduler
     }
 
     @discardableResult
-    func renew(completion: @escaping (RenewRunResult) -> Void) -> Bool {
+    func renew(completion: @escaping (RenewRunResult, [RenewHistoryValue]?) -> Void) -> Bool {
         stateLock.lock()
-        if isInFlight {
+        guard activeOperation == nil else {
             stateLock.unlock()
-            DispatchQueue.main.async { completion(.rejected) }
+            DispatchQueue.main.async { completion(.rejected, nil) }
             return false
         }
-        isInFlight = true
-        stateLock.unlock()
 
-        store.snapshotForRenew { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .failure(let error):
-                self.finish(RenewRunResult(
-                    accepted: true, requestedCount: 0, successfulCalculationCount: 0,
-                    appliedCount: 0, changedCount: 0, saveError: error
-                ), completion: completion)
-            case .success(let rows):
-                self.calculate(rows: rows, completion: completion)
-            }
-        }
+        let operation = AtomicRenewOperation(
+            store: store, converter: converter, timeout: timeout, scheduler: scheduler,
+            owner: self, completion: completion
+        )
+        activeOperation = operation
+        stateLock.unlock()
+        operation.start()
         return true
     }
 
-    private func calculate(rows: [RenewRowSnapshot], completion: @escaping (RenewRunResult) -> Void) {
+    fileprivate func operationDidFinish(_ operation: AtomicRenewOperation) {
+        stateLock.lock()
+        if activeOperation === operation {
+            activeOperation = nil
+        }
+        stateLock.unlock()
+    }
+}
+
+private final class AtomicRenewOperation {
+    private let stateLock = NSLock()
+    private let store: AtomicRenewStore
+    private let converter: RenewConverter
+    private let timeout: TimeInterval
+    private let scheduler: AtomicRenewScheduler
+    private var owner: AtomicRenewWorkflow?
+    private let completion: (RenewRunResult, [RenewHistoryValue]?) -> Void
+    private let calculationQueue = DispatchQueue(label: "CurrencyConverter.atomic-renew.calculations", attributes: .concurrent)
+    private var isActive = true
+    private var stage: RenewTimeoutStage = .snapshot
+    private var requestedCount = 0
+    private var successfulCalculationCount = 0
+    private var appliedCount = 0
+    private var changedCount = 0
+    private var timeoutTask: AtomicRenewScheduledTask?
+    private var keepAlive: AtomicRenewOperation?
+
+    init(
+        store: AtomicRenewStore,
+        converter: RenewConverter,
+        timeout: TimeInterval,
+        scheduler: AtomicRenewScheduler,
+        owner: AtomicRenewWorkflow,
+        completion: @escaping (RenewRunResult, [RenewHistoryValue]?) -> Void
+    ) {
+        self.store = store
+        self.converter = converter
+        self.timeout = timeout
+        self.scheduler = scheduler
+        self.owner = owner
+        self.completion = completion
+    }
+
+    func start() {
+        keepAlive = self
+        let scheduled = scheduler.schedule(after: timeout) { [weak self] in
+            self?.timeoutFired()
+        }
+        stateLock.lock()
+        if isActive {
+            timeoutTask = scheduled
+            stateLock.unlock()
+        } else {
+            stateLock.unlock()
+            scheduled.cancel()
+        }
+
+        let snapshotGate = RenewOneShot<Result<[RenewRowSnapshot], Error>>()
+        store.snapshotForRenew { [weak self] result in
+            snapshotGate.consume(result) { result in
+                guard let self, self.isActiveNow() else { return }
+                switch result {
+                case .failure(let error):
+                    self.finish(
+                        result: RenewRunResult(
+                            accepted: true, requestedCount: 0, successfulCalculationCount: 0,
+                            appliedCount: 0, changedCount: 0,
+                            snapshotError: .failed(error), timeoutError: nil,
+                            saveError: nil, historyError: nil
+                        ), history: nil
+                    )
+                case .success(let rows):
+                    self.setCounts(requested: rows.count)
+                    self.calculate(rows: rows)
+                }
+            }
+        }
+    }
+
+    private func calculate(rows: [RenewRowSnapshot]) {
+        setStage(.conversion)
         let group = DispatchGroup()
         let resultLock = NSLock()
-        var completedIndexes = Set<Int>()
         var successfulRatios: [Int: Float32] = [:]
 
         for (index, row) in rows.enumerated() {
             group.enter()
             calculationQueue.async { [weak self] in
+                let rowGate = RenewOneShot<Float32?>()
+                let complete: (Float32?) -> Void = { [weak self] ratio in
+                    rowGate.consume(ratio) { ratio in
+                        if let self, self.isActiveNow() {
+                            resultLock.lock()
+                            if let ratio {
+                                successfulRatios[index] = ratio
+                            }
+                            resultLock.unlock()
+                        }
+                        group.leave()
+                    }
+                }
+
                 guard let self else {
-                    group.leave()
+                    complete(nil)
                     return
                 }
-
-                let complete: (Float32?) -> Void = { ratio in
-                    resultLock.lock()
-                    guard completedIndexes.insert(index).inserted else {
-                        resultLock.unlock()
-                        return
-                    }
-                    if let ratio { successfulRatios[index] = ratio }
-                    resultLock.unlock()
-                    group.leave()
-                }
-
                 guard let from = row.fromSymbol, let to = row.toSymbol,
                       !from.isEmpty, !to.isEmpty else {
                     complete(nil)
                     return
                 }
+                // The ticket explicitly treats same-currency conversion as a ratio of 1,
+                // including zero and non-finite source amounts, without touching the network.
                 if from == to {
                     complete(1)
                     return
@@ -215,31 +355,143 @@ final class AtomicRenewCoordinator {
         }
 
         group.notify(queue: calculationQueue) { [weak self] in
-            guard let self else { return }
+            guard let self, self.beginApply() else { return }
             resultLock.lock()
             let updates = rows.enumerated().compactMap { index, row -> RenewUpdate? in
                 guard let ratio = successfulRatios[index] else { return nil }
-                return RenewUpdate(objectID: row.objectID, businessID: row.businessID, ratio: ratio)
+                return RenewUpdate(row: row, ratio: ratio)
             }
             let successfulCount = successfulRatios.count
             resultLock.unlock()
+            self.setCounts(successful: successfulCount)
 
-            self.store.applyRenew(updates: updates) { outcome in
-                self.finish(RenewRunResult(
-                    accepted: true, requestedCount: rows.count,
-                    successfulCalculationCount: successfulCount,
-                    appliedCount: outcome.appliedCount,
-                    changedCount: outcome.changedCount,
-                    saveError: outcome.saveError
-                ), completion: completion)
+            let applyGate = RenewOneShot<RenewApplyOutcome>()
+            self.store.applyRenew(updates: updates) { [weak self] outcome in
+                applyGate.consume(outcome) { outcome in
+                    guard let self, self.isActiveNow() else { return }
+                    self.readHistory(
+                        requestedCount: rows.count,
+                        successfulCount: successfulCount,
+                        outcome: outcome
+                    )
+                }
             }
         }
     }
 
-    private func finish(_ result: RenewRunResult, completion: @escaping (RenewRunResult) -> Void) {
+    private func readHistory(requestedCount: Int, successfulCount: Int, outcome: RenewApplyOutcome) {
+        setStage(.history)
+        setCounts(applied: outcome.appliedCount, changed: outcome.changedCount)
+        let historyGate = RenewOneShot<Result<[RenewHistoryValue], Error>>()
+        store.readHistory { [weak self] result in
+            historyGate.consume(result) { result in
+                guard let self, self.isActiveNow() else { return }
+                switch result {
+                case .success(let values):
+                    self.finish(
+                        result: RenewRunResult(
+                            accepted: true, requestedCount: requestedCount,
+                            successfulCalculationCount: successfulCount,
+                            appliedCount: outcome.appliedCount, changedCount: outcome.changedCount,
+                            snapshotError: nil, timeoutError: nil,
+                            saveError: outcome.saveError.map(RenewSaveError.failed),
+                            historyError: nil
+                        ), history: values
+                    )
+                case .failure(let error):
+                    self.finish(
+                        result: RenewRunResult(
+                            accepted: true, requestedCount: requestedCount,
+                            successfulCalculationCount: successfulCount,
+                            appliedCount: outcome.appliedCount, changedCount: outcome.changedCount,
+                            snapshotError: nil, timeoutError: nil,
+                            saveError: outcome.saveError.map(RenewSaveError.failed),
+                            historyError: .failed(error)
+                        ), history: nil
+                    )
+                }
+            }
+        }
+    }
+
+    private func beginApply() -> Bool {
         stateLock.lock()
-        isInFlight = false
+        guard isActive else {
+            stateLock.unlock()
+            return false
+        }
+        stage = .apply
         stateLock.unlock()
-        DispatchQueue.main.async { completion(result) }
+        return true
+    }
+
+    private func setStage(_ newStage: RenewTimeoutStage) {
+        stateLock.lock()
+        if isActive {
+            stage = newStage
+        }
+        stateLock.unlock()
+    }
+
+    private func setCounts(
+        requested: Int? = nil,
+        successful: Int? = nil,
+        applied: Int? = nil,
+        changed: Int? = nil
+    ) {
+        stateLock.lock()
+        if isActive {
+            if let requested { requestedCount = requested }
+            if let successful { successfulCalculationCount = successful }
+            if let applied { appliedCount = applied }
+            if let changed { changedCount = changed }
+        }
+        stateLock.unlock()
+    }
+
+    private func isActiveNow() -> Bool {
+        stateLock.lock()
+        let active = isActive
+        stateLock.unlock()
+        return active
+    }
+
+    private func timeoutFired() {
+        stateLock.lock()
+        let timedOutStage = stage
+        let requestedCount = requestedCount
+        let successfulCalculationCount = successfulCalculationCount
+        let appliedCount = appliedCount
+        let changedCount = changedCount
+        stateLock.unlock()
+        finish(
+            result: RenewRunResult(
+                accepted: true, requestedCount: requestedCount,
+                successfulCalculationCount: successfulCalculationCount,
+                appliedCount: appliedCount, changedCount: changedCount, snapshotError: nil,
+                timeoutError: .expired(timedOutStage), saveError: nil, historyError: nil
+            ), history: nil
+        )
+    }
+
+    private func finish(result: RenewRunResult, history: [RenewHistoryValue]?) {
+        stateLock.lock()
+        guard isActive else {
+            stateLock.unlock()
+            return
+        }
+        isActive = false
+        let task = timeoutTask
+        timeoutTask = nil
+        stateLock.unlock()
+        task?.cancel()
+
+        let owner = owner
+        owner?.operationDidFinish(self)
+        self.owner = nil
+        DispatchQueue.main.async { [completion] in
+            completion(result, history)
+        }
+        keepAlive = nil
     }
 }

--- a/Shared/AtomicRenew.swift
+++ b/Shared/AtomicRenew.swift
@@ -2,8 +2,7 @@ import Foundation
 import CryptoKit
 
 enum RenewPresentationIdentity {
-    static func id(businessID: UUID?, objectIDURI: String) -> UUID {
-        _ = businessID
+    static func id(objectIDURI: String) -> UUID {
         var bytes = Array(SHA256.hash(data: Data(objectIDURI.utf8)))
         // This is a deterministic SHA-256 construction, not RFC 4122 UUIDv5.
         bytes[6] = (bytes[6] & 0x0F) | 0x80
@@ -486,12 +485,12 @@ private final class AtomicRenewOperation {
         stateLock.unlock()
         task?.cancel()
 
-        let owner = owner
-        owner?.operationDidFinish(self)
-        self.owner = nil
-        DispatchQueue.main.async { [completion] in
+        DispatchQueue.main.async { [self] in
             completion(result, history)
+            let currentOwner = owner
+            currentOwner?.operationDidFinish(self)
+            owner = nil
+            keepAlive = nil
         }
-        keepAlive = nil
     }
 }

--- a/Shared/AtomicRenew.swift
+++ b/Shared/AtomicRenew.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+struct RenewRowSnapshot: Equatable {
+    let objectID: String
+    let businessID: UUID?
+    let fromSymbol: String?
+    let toSymbol: String?
+    let fromAmount: Float32
+    let ratio: Float32
+}
+
+struct RenewUpdate: Equatable {
+    let objectID: String
+    let businessID: UUID?
+    let ratio: Float32
+}
+
+struct RenewHistoryValue {
+    let id: UUID?
+    let title: String?
+    let url: String?
+    let fromSymbol: String?
+    let toSymbol: String?
+    let fromAmount: Float32
+    let fxFee: Float32
+    let ratio: Float32
+}
+
+struct RenewApplyOutcome {
+    let appliedCount: Int
+    let changedCount: Int
+    let saveError: Error?
+}
+
+struct RenewRunResult {
+    let accepted: Bool
+    let requestedCount: Int
+    let successfulCalculationCount: Int
+    let appliedCount: Int
+    let changedCount: Int
+    let saveError: Error?
+
+    static let rejected = RenewRunResult(
+        accepted: false, requestedCount: 0, successfulCalculationCount: 0,
+        appliedCount: 0, changedCount: 0, saveError: nil
+    )
+}
+
+protocol AtomicRenewStore: AnyObject {
+    func snapshotForRenew(completion: @escaping (Result<[RenewRowSnapshot], Error>) -> Void)
+    func applyRenew(updates: [RenewUpdate], completion: @escaping (RenewApplyOutcome) -> Void)
+    func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void)
+    func wipeAll()
+    func wipeById(_ id: UUID)
+}
+
+protocol RenewConverter: AnyObject {
+    func convert(from: String, to: String, unit: Float32, completionHandler: @escaping (Float32, Error?) -> Void)
+}
+
+extension CurrencyConverter: RenewConverter {}
+
+final class AtomicRenewCoordinator {
+    private let store: AtomicRenewStore
+    private let converter: RenewConverter
+    private let stateLock = NSLock()
+    private let calculationQueue = DispatchQueue(label: "CurrencyConverter.atomic-renew.calculations", attributes: .concurrent)
+    private var isInFlight = false
+
+    init(store: AtomicRenewStore, converter: RenewConverter) {
+        self.store = store
+        self.converter = converter
+    }
+
+    @discardableResult
+    func renew(completion: @escaping (RenewRunResult) -> Void) -> Bool {
+        stateLock.lock()
+        if isInFlight {
+            stateLock.unlock()
+            DispatchQueue.main.async { completion(.rejected) }
+            return false
+        }
+        isInFlight = true
+        stateLock.unlock()
+
+        store.snapshotForRenew { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .failure(let error):
+                self.finish(RenewRunResult(
+                    accepted: true, requestedCount: 0, successfulCalculationCount: 0,
+                    appliedCount: 0, changedCount: 0, saveError: error
+                ), completion: completion)
+            case .success(let rows):
+                self.calculate(rows: rows, completion: completion)
+            }
+        }
+        return true
+    }
+
+    private func calculate(rows: [RenewRowSnapshot], completion: @escaping (RenewRunResult) -> Void) {
+        let group = DispatchGroup()
+        let resultLock = NSLock()
+        var completedIndexes = Set<Int>()
+        var successfulRatios: [Int: Float32] = [:]
+
+        for (index, row) in rows.enumerated() {
+            group.enter()
+            calculationQueue.async { [weak self] in
+                guard let self else {
+                    group.leave()
+                    return
+                }
+
+                let complete: (Float32?) -> Void = { ratio in
+                    resultLock.lock()
+                    guard completedIndexes.insert(index).inserted else {
+                        resultLock.unlock()
+                        return
+                    }
+                    if let ratio { successfulRatios[index] = ratio }
+                    resultLock.unlock()
+                    group.leave()
+                }
+
+                guard let from = row.fromSymbol, let to = row.toSymbol,
+                      !from.isEmpty, !to.isEmpty else {
+                    complete(nil)
+                    return
+                }
+                if from == to {
+                    complete(1)
+                    return
+                }
+                guard row.fromAmount.isFinite, row.fromAmount != 0 else {
+                    complete(nil)
+                    return
+                }
+
+                self.converter.convert(from: from, to: to, unit: row.fromAmount) { amount, error in
+                    guard error == nil, amount.isFinite else {
+                        complete(nil)
+                        return
+                    }
+                    let ratio = amount / row.fromAmount
+                    complete(ratio.isFinite ? ratio : nil)
+                }
+            }
+        }
+
+        group.notify(queue: calculationQueue) { [weak self] in
+            guard let self else { return }
+            resultLock.lock()
+            let updates = rows.enumerated().compactMap { index, row -> RenewUpdate? in
+                guard let ratio = successfulRatios[index] else { return nil }
+                return RenewUpdate(objectID: row.objectID, businessID: row.businessID, ratio: ratio)
+            }
+            let successfulCount = successfulRatios.count
+            resultLock.unlock()
+
+            self.store.applyRenew(updates: updates) { outcome in
+                self.finish(RenewRunResult(
+                    accepted: true, requestedCount: rows.count,
+                    successfulCalculationCount: successfulCount,
+                    appliedCount: outcome.appliedCount,
+                    changedCount: outcome.changedCount,
+                    saveError: outcome.saveError
+                ), completion: completion)
+            }
+        }
+    }
+
+    private func finish(_ result: RenewRunResult, completion: @escaping (RenewRunResult) -> Void) {
+        stateLock.lock()
+        isInFlight = false
+        stateLock.unlock()
+        DispatchQueue.main.async { completion(result) }
+    }
+}

--- a/Shared/CHDataManager.swift
+++ b/Shared/CHDataManager.swift
@@ -40,15 +40,33 @@ class CHDataManager {
     func wipeById(_ at: UUID) {
         let vc = context
         vc.performAndWait {
-            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ConvertHistory")
-            let predicate = NSPredicate(format: "id == %@", at as CVarArg)
-            fetchRequest.predicate = predicate
-            if let result = try? vc.fetch(fetchRequest) {
-                for object in result {
-                    vc.delete(object as! NSManagedObject)
+            do {
+                let businessIDRequest = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+                businessIDRequest.predicate = NSPredicate(format: "id == %@", at as CVarArg)
+                let businessIDMatches = try vc.fetch(businessIDRequest)
+                if !businessIDMatches.isEmpty {
+                    businessIDMatches.forEach { vc.delete($0) }
+                    try vc.save()
+                    return
                 }
+
+                let nilIDRequest = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+                nilIDRequest.predicate = NSPredicate(format: "id == nil")
+                let nilIDRows = try vc.fetch(nilIDRequest)
+                try ensurePermanentIDs(for: nilIDRows)
+                guard let fallbackMatch = nilIDRows.first(where: { object in
+                    RenewPresentationIdentity.id(
+                        businessID: object.id,
+                        objectIDURI: object.objectID.uriRepresentation().absoluteString
+                    ) == at
+                }) else {
+                    return
+                }
+                vc.delete(fallbackMatch)
+                try vc.save()
+            } catch {
+                vc.rollback()
             }
-            try! vc.save()
         }
     }
 

--- a/Shared/CHDataManager.swift
+++ b/Shared/CHDataManager.swift
@@ -46,7 +46,6 @@ class CHDataManager {
                 try ensurePermanentIDs(for: objects)
                 guard let match = objects.first(where: { object in
                     RenewPresentationIdentity.id(
-                        businessID: object.id,
                         objectIDURI: object.objectID.uriRepresentation().absoluteString
                     ) == at
                 }) else {

--- a/Shared/CHDataManager.swift
+++ b/Shared/CHDataManager.swift
@@ -11,45 +11,149 @@ import CoreData
 
 class CHDataManager {
     static let shared = CHDataManager()
+
+    private let context: NSManagedObjectContext
+    private let saveOperation: (() throws -> Void)?
+
+    init(context: NSManagedObjectContext = sharedPersistentContainer.viewContext, saveOperation: (() throws -> Void)? = nil) {
+        self.context = context
+        self.saveOperation = saveOperation
+    }
     
     func readFromCore() -> [ConvertHistory]? {
-        let vc = sharedPersistentContainer.viewContext
+        let vc = context
         let fetchRequst = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
         let sort = NSSortDescriptor(keyPath: \ConvertHistory.date, ascending: false)
         fetchRequst.sortDescriptors = [sort]
-        let objects = try? vc.fetch(fetchRequst) as? [ConvertHistory]
-        
-        if let objects = objects {
-            for i in objects.indices {
-                if objects[i].id == nil {
-                    objects[i].id = UUID()
-                }
-            }
-            return objects
+        var objects: [ConvertHistory]?
+        vc.performAndWait {
+            objects = try? vc.fetch(fetchRequst) as? [ConvertHistory]
         }
-        
-        return nil
+        return objects
     }
     
     func wipeAll() {
-        let vc = sharedPersistentContainer.viewContext
+        let vc = context
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ConvertHistory")
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-        try! vc.execute(deleteRequest)
+        vc.performAndWait {
+            try! vc.execute(deleteRequest)
+        }
     }
     
     func wipeById(_ at: UUID) {
-        let vc = sharedPersistentContainer.viewContext
-        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ConvertHistory")
-        let predicate = NSPredicate(format: "id = '\(at)'")
-        fetchRequest.predicate = predicate
-        if let result = try? vc.fetch(fetchRequest) {
-            for object in result {
-                vc.delete(object as! NSManagedObject)
+        let vc = context
+        vc.performAndWait {
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ConvertHistory")
+            let predicate = NSPredicate(format: "id = '\(at)'")
+            fetchRequest.predicate = predicate
+            if let result = try? vc.fetch(fetchRequest) {
+                for object in result {
+                    vc.delete(object as! NSManagedObject)
+                }
             }
+            try! vc.save()
         }
-        try! vc.save()
     }
 
     
+}
+
+extension CHDataManager: AtomicRenewStore {
+    func snapshotForRenew(completion: @escaping (Result<[RenewRowSnapshot], Error>) -> Void) {
+        context.perform {
+            do {
+                let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+                request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+                let objects = try self.context.fetch(request)
+                completion(.success(objects.map { object in
+                    RenewRowSnapshot(
+                        objectID: object.objectID.uriRepresentation().absoluteString,
+                        businessID: object.id,
+                        fromSymbol: object.fromSymbol,
+                        toSymbol: object.toSymbol,
+                        fromAmount: object.fromAmount,
+                        ratio: object.ratio
+                    )
+                }))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func applyRenew(updates: [RenewUpdate], completion: @escaping (RenewApplyOutcome) -> Void) {
+        context.perform {
+            do {
+                let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+                let objects = try self.context.fetch(request)
+                var byObjectID: [String: ConvertHistory] = [:]
+                for object in objects {
+                    byObjectID[object.objectID.uriRepresentation().absoluteString] = object
+                }
+
+                var changedObjects: [(ConvertHistory, Float32)] = []
+                var matchedObjectIDs = Set<String>()
+                for update in updates {
+                    guard matchedObjectIDs.insert(update.objectID).inserted,
+                          let object = byObjectID[update.objectID],
+                          object.objectID.uriRepresentation().absoluteString == update.objectID,
+                          object.id == update.businessID,
+                          !object.isDeleted else {
+                        continue
+                    }
+                    if object.ratio != update.ratio {
+                        changedObjects.append((object, object.ratio))
+                        object.ratio = update.ratio
+                    }
+                }
+
+                guard !changedObjects.isEmpty else {
+                    completion(RenewApplyOutcome(appliedCount: 0, changedCount: 0, saveError: nil))
+                    return
+                }
+
+                do {
+                    if let saveOperation = self.saveOperation {
+                        try saveOperation()
+                    } else {
+                        try self.context.save()
+                    }
+                    completion(RenewApplyOutcome(
+                        appliedCount: changedObjects.count,
+                        changedCount: changedObjects.count,
+                        saveError: nil
+                    ))
+                } catch {
+                    for (object, oldRatio) in changedObjects {
+                        object.ratio = oldRatio
+                    }
+                    self.context.rollback()
+                    completion(RenewApplyOutcome(appliedCount: 0, changedCount: 0, saveError: error))
+                }
+            } catch {
+                completion(RenewApplyOutcome(appliedCount: 0, changedCount: 0, saveError: error))
+            }
+        }
+    }
+
+    func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void) {
+        context.perform {
+            let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+            request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+            let values = (try? self.context.fetch(request))?.map { object in
+                RenewHistoryValue(
+                    id: object.id,
+                    title: object.title,
+                    url: object.url,
+                    fromSymbol: object.fromSymbol,
+                    toSymbol: object.toSymbol,
+                    fromAmount: object.fromAmount,
+                    fxFee: object.fxFee,
+                    ratio: object.ratio
+                )
+            } ?? []
+            completion(values)
+        }
+    }
 }

--- a/Shared/CHDataManager.swift
+++ b/Shared/CHDataManager.swift
@@ -12,24 +12,20 @@ import CoreData
 class CHDataManager {
     static let shared = CHDataManager()
 
+    // Renew owns this private queue/context. It must never save or roll back the UI viewContext.
     private let context: NSManagedObjectContext
     private let saveOperation: (() throws -> Void)?
 
-    init(context: NSManagedObjectContext = sharedPersistentContainer.viewContext, saveOperation: (() throws -> Void)? = nil) {
-        self.context = context
+    init(context: NSManagedObjectContext? = nil, saveOperation: (() throws -> Void)? = nil) {
+        self.context = context ?? sharedPersistentContainer.newBackgroundContext()
         self.saveOperation = saveOperation
     }
-    
-    func readFromCore() -> [ConvertHistory]? {
-        let vc = context
-        let fetchRequst = NSFetchRequest<NSManagedObject>(entityName: "ConvertHistory")
-        let sort = NSSortDescriptor(keyPath: \ConvertHistory.date, ascending: false)
-        fetchRequst.sortDescriptors = [sort]
-        var objects: [ConvertHistory]?
-        vc.performAndWait {
-            objects = try? vc.fetch(fetchRequst) as? [ConvertHistory]
+
+    private func ensurePermanentIDs(for objects: [ConvertHistory]) throws {
+        let temporaryObjects = objects.filter { $0.objectID.isTemporaryID }
+        if !temporaryObjects.isEmpty {
+            try context.obtainPermanentIDs(for: temporaryObjects)
         }
-        return objects
     }
     
     func wipeAll() {
@@ -45,7 +41,7 @@ class CHDataManager {
         let vc = context
         vc.performAndWait {
             let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ConvertHistory")
-            let predicate = NSPredicate(format: "id = '\(at)'")
+            let predicate = NSPredicate(format: "id == %@", at as CVarArg)
             fetchRequest.predicate = predicate
             if let result = try? vc.fetch(fetchRequest) {
                 for object in result {
@@ -66,6 +62,7 @@ extension CHDataManager: AtomicRenewStore {
                 let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
                 request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
                 let objects = try self.context.fetch(request)
+                try self.ensurePermanentIDs(for: objects)
                 completion(.success(objects.map { object in
                     RenewRowSnapshot(
                         objectID: object.objectID.uriRepresentation().absoluteString,
@@ -139,20 +136,28 @@ extension CHDataManager: AtomicRenewStore {
 
     func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void) {
         context.perform {
-            let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
-            request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
-            let values = (try? self.context.fetch(request))?.map { object in
-                RenewHistoryValue(
-                    id: object.id,
-                    title: object.title,
-                    url: object.url,
-                    fromSymbol: object.fromSymbol,
-                    toSymbol: object.toSymbol,
-                    fromAmount: object.fromAmount,
-                    fxFee: object.fxFee,
-                    ratio: object.ratio
-                )
-            } ?? []
+            let values: [RenewHistoryValue]
+            do {
+                let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+                request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+                let objects = try self.context.fetch(request)
+                try self.ensurePermanentIDs(for: objects)
+                values = objects.map { object in
+                    RenewHistoryValue(
+                        objectID: object.objectID.uriRepresentation().absoluteString,
+                        id: object.id,
+                        title: object.title,
+                        url: object.url,
+                        fromSymbol: object.fromSymbol,
+                        toSymbol: object.toSymbol,
+                        fromAmount: object.fromAmount,
+                        fxFee: object.fxFee,
+                        ratio: object.ratio
+                    )
+                }
+            } catch {
+                values = []
+            }
             completion(values)
         }
     }

--- a/Shared/CHDataManager.swift
+++ b/Shared/CHDataManager.swift
@@ -41,20 +41,10 @@ class CHDataManager {
         let vc = context
         vc.performAndWait {
             do {
-                let businessIDRequest = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
-                businessIDRequest.predicate = NSPredicate(format: "id == %@", at as CVarArg)
-                let businessIDMatches = try vc.fetch(businessIDRequest)
-                if !businessIDMatches.isEmpty {
-                    businessIDMatches.forEach { vc.delete($0) }
-                    try vc.save()
-                    return
-                }
-
-                let nilIDRequest = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
-                nilIDRequest.predicate = NSPredicate(format: "id == nil")
-                let nilIDRows = try vc.fetch(nilIDRequest)
-                try ensurePermanentIDs(for: nilIDRows)
-                guard let fallbackMatch = nilIDRows.first(where: { object in
+                let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
+                let objects = try vc.fetch(request)
+                try ensurePermanentIDs(for: objects)
+                guard let match = objects.first(where: { object in
                     RenewPresentationIdentity.id(
                         businessID: object.id,
                         objectIDURI: object.objectID.uriRepresentation().absoluteString
@@ -62,7 +52,7 @@ class CHDataManager {
                 }) else {
                     return
                 }
-                vc.delete(fallbackMatch)
+                vc.delete(match)
                 try vc.save()
             } catch {
                 vc.rollback()
@@ -100,6 +90,9 @@ extension CHDataManager: AtomicRenewStore {
     func applyRenew(updates: [RenewUpdate], completion: @escaping (RenewApplyOutcome) -> Void) {
         context.perform {
             do {
+                // The renewal context can have registered objects from the snapshot.
+                // Refresh before comparing so edits saved by another context are visible.
+                self.context.refreshAllObjects()
                 let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
                 let objects = try self.context.fetch(request)
                 var byObjectID: [String: ConvertHistory] = [:]
@@ -114,6 +107,10 @@ extension CHDataManager: AtomicRenewStore {
                           let object = byObjectID[update.objectID],
                           object.objectID.uriRepresentation().absoluteString == update.objectID,
                           object.id == update.businessID,
+                          object.fromSymbol == update.originalFromSymbol,
+                          object.toSymbol == update.originalToSymbol,
+                          object.fromAmount.bitPattern == update.originalFromAmountBitPattern,
+                          object.ratio.bitPattern == update.originalRatioBitPattern,
                           !object.isDeleted else {
                         continue
                     }
@@ -152,15 +149,14 @@ extension CHDataManager: AtomicRenewStore {
         }
     }
 
-    func readHistory(completion: @escaping ([RenewHistoryValue]) -> Void) {
+    func readHistory(completion: @escaping (Result<[RenewHistoryValue], Error>) -> Void) {
         context.perform {
-            let values: [RenewHistoryValue]
             do {
                 let request = NSFetchRequest<ConvertHistory>(entityName: "ConvertHistory")
                 request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
                 let objects = try self.context.fetch(request)
                 try self.ensurePermanentIDs(for: objects)
-                values = objects.map { object in
+                let values = objects.map { object in
                     RenewHistoryValue(
                         objectID: object.objectID.uriRepresentation().absoluteString,
                         id: object.id,
@@ -173,10 +169,10 @@ extension CHDataManager: AtomicRenewStore {
                         ratio: object.ratio
                     )
                 }
+                completion(.success(values))
             } catch {
-                values = []
+                completion(.failure(error))
             }
-            completion(values)
         }
     }
 }

--- a/Shared/ConvertHistoryUIBeanProduction.swift
+++ b/Shared/ConvertHistoryUIBeanProduction.swift
@@ -1,29 +1,6 @@
 import Foundation
 
-struct ConvertHistoryUIBean: Identifiable {
-    var id: UUID
-    var title: String?
-    var url: String
-    var fromSymbol: String
-    var toSymbol: String
-    var fromAmount: Float
-
-    var toAmount: Float {
-        LegacyConvertHistoryCalculations.toAmount(fromAmount: fromAmount, ratio: ratio)
-    }
-
-    var fxFee: Float {
-        LegacyConvertHistoryCalculations.fxFee(toAmount: toAmount, fxFeeRate: fxFeeRate)
-    }
-
-    var toAmountWithFx: Float {
-        LegacyConvertHistoryCalculations.toAmountWithFx(toAmount: toAmount, fxFeeRate: fxFeeRate)
-    }
-
-    var fxFeeRate: Float
-    var ratio: Float
-    var isChecked = false
-
+extension ConvertHistoryUIBean {
     static func fromCoreData(c: ConvertHistoryRecord) -> ConvertHistoryUIBean {
         let values = LegacyConvertHistoryCalculations.normalizedHistoryValues(
             fromSymbol: c.fromSymbol, toSymbol: c.toSymbol, fxFeeRate: c.fxFee, ratio: c.ratio

--- a/Shared/ConvertHistoryUIBeanProduction.swift
+++ b/Shared/ConvertHistoryUIBeanProduction.swift
@@ -42,9 +42,17 @@ enum RenewPresentationOrchestration {
         }
     }
 
-    static func reload(from store: AtomicRenewStore, completion: @escaping ([ConvertHistoryUIBean]) -> Void) {
+    static func reload(
+        from store: AtomicRenewStore,
+        completion: @escaping (Result<[ConvertHistoryUIBean], Error>) -> Void
+    ) {
         store.readHistory { values in
-            completion(beans(from: values))
+            switch values {
+            case .success(let values):
+                completion(.success(beans(from: values)))
+            case .failure(let error):
+                completion(.failure(error))
+            }
         }
     }
 }
@@ -54,8 +62,11 @@ extension ConvertHistoryUIBean {
         let values = LegacyConvertHistoryCalculations.normalizedHistoryValues(
             fromSymbol: c.fromSymbol, toSymbol: c.toSymbol, fxFeeRate: c.fxFee, ratio: c.ratio
         )
+        let presentationID = c.objectIDURI.map {
+            RenewPresentationIdentity.id(businessID: c.id, objectIDURI: $0)
+        } ?? c.id ?? UUID()
         return ConvertHistoryUIBean(
-            id: c.id ?? UUID(), title: c.title ?? "", url: c.url ?? "",
+            id: presentationID, title: c.title ?? "", url: c.url ?? "",
             fromSymbol: c.fromSymbol ?? "", toSymbol: c.toSymbol ?? "", fromAmount: c.fromAmount,
             fxFeeRate: values.fxFeeRate, ratio: values.ratio
         )
@@ -71,4 +82,9 @@ protocol ConvertHistoryRecord {
     var fromAmount: Float { get }
     var fxFee: Float { get }
     var ratio: Float { get }
+    var objectIDURI: String? { get }
+}
+
+extension ConvertHistoryRecord {
+    var objectIDURI: String? { nil }
 }

--- a/Shared/ConvertHistoryUIBeanProduction.swift
+++ b/Shared/ConvertHistoryUIBeanProduction.swift
@@ -33,7 +33,7 @@ enum RenewPresentationOrchestration {
                 fxFeeRate: value.fxFee, ratio: value.ratio
             )
             return ConvertHistoryUIBean(
-                id: RenewPresentationIdentity.id(businessID: value.id, objectIDURI: value.objectID),
+                id: RenewPresentationIdentity.id(objectIDURI: value.objectID),
                 title: value.title ?? "", url: value.url ?? "",
                 fromSymbol: value.fromSymbol ?? "", toSymbol: value.toSymbol ?? "",
                 fromAmount: value.fromAmount, fxFeeRate: normalized.fxFeeRate,
@@ -63,7 +63,7 @@ extension ConvertHistoryUIBean {
             fromSymbol: c.fromSymbol, toSymbol: c.toSymbol, fxFeeRate: c.fxFee, ratio: c.ratio
         )
         let presentationID = c.objectIDURI.map {
-            RenewPresentationIdentity.id(businessID: c.id, objectIDURI: $0)
+            RenewPresentationIdentity.id(objectIDURI: $0)
         } ?? c.id ?? UUID()
         return ConvertHistoryUIBean(
             id: presentationID, title: c.title ?? "", url: c.url ?? "",

--- a/Shared/ConvertHistoryUIBeanProduction.swift
+++ b/Shared/ConvertHistoryUIBeanProduction.swift
@@ -1,5 +1,54 @@
 import Foundation
 
+struct ConvertHistoryUIBean: Identifiable {
+    var id: UUID
+    var title: String?
+    var url: String
+    var fromSymbol: String
+    var toSymbol: String
+    var fromAmount: Float
+
+    var toAmount: Float {
+        LegacyConvertHistoryCalculations.toAmount(fromAmount: fromAmount, ratio: ratio)
+    }
+
+    var fxFee: Float {
+        LegacyConvertHistoryCalculations.fxFee(toAmount: toAmount, fxFeeRate: fxFeeRate)
+    }
+
+    var toAmountWithFx: Float {
+        LegacyConvertHistoryCalculations.toAmountWithFx(toAmount: toAmount, fxFeeRate: fxFeeRate)
+    }
+
+    var fxFeeRate: Float
+    var ratio: Float
+    var isChecked = false
+}
+
+enum RenewPresentationOrchestration {
+    static func beans(from values: [RenewHistoryValue]) -> [ConvertHistoryUIBean] {
+        values.map { value in
+            let normalized = LegacyConvertHistoryCalculations.normalizedHistoryValues(
+                fromSymbol: value.fromSymbol, toSymbol: value.toSymbol,
+                fxFeeRate: value.fxFee, ratio: value.ratio
+            )
+            return ConvertHistoryUIBean(
+                id: RenewPresentationIdentity.id(businessID: value.id, objectIDURI: value.objectID),
+                title: value.title ?? "", url: value.url ?? "",
+                fromSymbol: value.fromSymbol ?? "", toSymbol: value.toSymbol ?? "",
+                fromAmount: value.fromAmount, fxFeeRate: normalized.fxFeeRate,
+                ratio: normalized.ratio
+            )
+        }
+    }
+
+    static func reload(from store: AtomicRenewStore, completion: @escaping ([ConvertHistoryUIBean]) -> Void) {
+        store.readHistory { values in
+            completion(beans(from: values))
+        }
+    }
+}
+
 extension ConvertHistoryUIBean {
     static func fromCoreData(c: ConvertHistoryRecord) -> ConvertHistoryUIBean {
         let values = LegacyConvertHistoryCalculations.normalizedHistoryValues(


### PR DESCRIPTION
## Summary
- Make Renew atomic, duplicate-free, context-confined, and bounded by a finite timeout.
- Use exact-once snapshot/converter/apply/read settlement and suppress late callbacks.
- Hold the overlap gate through successful history read and synchronous main-thread publication.
- Skip rows whose source fields or original ratio changed after snapshot while preserving unrelated successes.
- Use permanent objectID-derived presentation/deletion identities; business UUIDs remain stored but do not define UI identity.
- Preserve the authoritative same-currency contract: ratio exactly 1 without network, including zero/nonfinite source values.

## Verification
- HEAD: `bbaf09f`
- Xcode 26.6 (`17F113`), arm64
- Focused CCS-21: 30 tests, 0 failures
- Full suite: 83 tests, 0 failures
- TSan CCS-21 + CCS-17 + CCS-10: 59 tests, 0 failures, 0 warnings/races
- App build: PASS
- Extension build: PASS
- Standalone test architecture and target settings: PASS; `TEST_HOST` / `BUNDLE_LOADER` absent
- Project/plist/Core Data/XIB/diff checks: PASS
- GitGuardian Security Checks: SUCCESS

## Review
- Immutable patch SHA-256: `ee8b2c41120035473fba9f9a93c1b5bd22a274d63225444e769a61b43c44ad8d`
- Fresh fail-closed spec review pending; do not merge until PASS.

YouTrack: CCS-21
