### PR TITLE
CCS-28: Remove committed API credentials and define safe rate-feed configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+Configuration/RateFeed.xcconfig

--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -1,0 +1,3 @@
+// Safe default: local/release builds may override this through the optional include.
+CURRENCY_INFO_FEED =
+#include? "RateFeed.xcconfig"

--- a/Configuration/RateFeed.xcconfig.example
+++ b/Configuration/RateFeed.xcconfig.example
@@ -1,0 +1,4 @@
+// Copy this file to RateFeed.xcconfig for a local or release build.
+// The endpoint must be credential-free HTTPS with no userinfo, query, or fragment.
+CURRENCY_INFO_FEED = https://rates.example.invalid/feed
+INFOPLIST_KEY_CurrencyInfoFeed = $(CURRENCY_INFO_FEED)

--- a/Configuration/RateFeed.xcconfig.example
+++ b/Configuration/RateFeed.xcconfig.example
@@ -1,4 +1,5 @@
 // Copy this file to RateFeed.xcconfig for a local or release build.
 // The endpoint must be credential-free HTTPS with no userinfo, query, or fragment.
-CURRENCY_INFO_FEED = https://rates.example.invalid/feed
-INFOPLIST_KEY_CurrencyInfoFeed = $(CURRENCY_INFO_FEED)
+CURRENCY_INFO_FEED = https:/$()/rates.example.invalid/feed
+// After Xcode expands the escaped slash, the processed plist contains:
+// https://rates.example.invalid/feed

--- a/CurrencyConverter Extension/Info.plist
+++ b/CurrencyConverter Extension/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CurrencyInfoFeed</key>
-	<string></string>
+	<string>$(CURRENCY_INFO_FEED)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSExtension</key>

--- a/CurrencyConverter Extension/Info.plist
+++ b/CurrencyConverter Extension/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CurrencyInfoFeed</key>
-	<string>https://api.rayer.idv.tw/currency?apiKey=Pa1EWFzg785sDLYbj4aWcp3C</string>
+	<string></string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSExtension</key>

--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS17RefreshCoalescingTests.swift; sourceTree = "<group>"; };
 		63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS10RateFallbackTests.swift; sourceTree = "<group>"; };
 		625712E62371982E00466679 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		62C49F31252AA15400ED2E72 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		625712F62371982E00466679 /* CurrencyConverter Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CurrencyConverter Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		625712FB2371982E00466679 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		625712FE2371982E00466679 /* SafariExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionHandler.swift; sourceTree = "<group>"; };
@@ -172,6 +173,7 @@
 		625712C42371982500466679 = {
 			isa = PBXGroup;
 			children = (
+				62C49F30252AA15400ED2E72 /* Configuration */,
 				6257131E23719B9800466679 /* Shared */,
 				625712E32371982E00466679 /* CurrencyConverterTests */,
 				625712FD2371982E00466679 /* CurrencyConverter Extension */,
@@ -202,6 +204,14 @@
 				62985BB6238464640022ED28 /* ConvertPasteboardFormatterTest.swift */,
 			);
 			path = CurrencyConverterTests;
+			sourceTree = "<group>";
+		};
+		62C49F30252AA15400ED2E72 /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				62C49F31252AA15400ED2E72 /* Base.xcconfig */,
+			);
+			path = Configuration;
 			sourceTree = "<group>";
 		};
 		625712FA2371982E00466679 /* Frameworks */ = {
@@ -628,6 +638,7 @@
 		};
 		6257130E2371982E00466679 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 62C49F31252AA15400ED2E72 /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "CurrencyConverter Extension/CurrencyConverter_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -652,6 +663,7 @@
 		};
 		6257130F2371982E00466679 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 62C49F31252AA15400ED2E72 /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "CurrencyConverter Extension/CurrencyConverter_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -716,6 +728,7 @@
 		};
 		628503AC251B937100E381AA /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 62C49F31252AA15400ED2E72 /* Base.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -744,6 +757,7 @@
 		};
 		628503AD251B937100E381AA /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 62C49F31252AA15400ED2E72 /* Base.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/CurrencyConverter/Info.plist
+++ b/CurrencyConverter/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CurrencyInfoFeed</key>
-	<string></string>
+	<string>$(CURRENCY_INFO_FEED)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.lifestyle</string>
 	<key>LSMinimumSystemVersion</key>

--- a/CurrencyConverter/Info.plist
+++ b/CurrencyConverter/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CurrencyInfoFeed</key>
-	<string>https://api.rayer.idv.tw/currency?apiKey=Pa1EWFzg785sDLYbj4aWcp3C</string>
+	<string></string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.lifestyle</string>
 	<key>LSMinimumSystemVersion</key>

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -717,6 +717,72 @@ final class CCS28SecurityTests: XCTestCase {
         XCTAssertEqual(transport.requestCount, 0)
     }
 
+    func testInjectedUnsafeSuccessURLsAreRejectedBeforeTransport() {
+        let unsafeValues = [
+            "https://rates.example.invalid/feed?",
+            "https://rates.example.invalid/feed#",
+            "https://" + "user" + "@rates.example.invalid/feed",
+            "https://rates.example.invalid:99999/feed",
+            "https://rates.example.invalid/feed%20with-space"
+        ]
+
+        for value in unsafeValues {
+            guard let url = URL(string: value) else {
+                return XCTFail("test URL should be representable")
+            }
+            let transport = CCS10Transport()
+            let converter = CurrencyConverter(
+                clock: { Date(timeIntervalSince1970: 1000) },
+                defaults: CCS10Defaults(),
+                feedConfiguration: .success(url),
+                transport: transport.send
+            )
+            let completed = expectation(description: "invalid injected feed")
+
+            converter.loadData { error in
+                XCTAssertEqual(error as? RateDataError, .invalidConfiguration)
+                XCTAssertEqual(converter.rateDataStatus.lastRefreshError, .invalidConfiguration)
+                completed.fulfill()
+            }
+
+            wait(for: [completed], timeout: 1)
+            XCTAssertEqual(transport.requestCount, 0)
+        }
+    }
+
+    func testScannerDetectsShortPrintableSensitiveAssignmentsWithoutEchoingValue() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let cases: [([String], String, String)] = [
+            (["api", "key"], "=", "!"),
+            (["secret", "key"], ":", "~"),
+            (["auth", "key"], "=", "#")
+        ]
+
+        for (parts, separator, valuePart) in cases {
+            let temporaryFile = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ccs28-short-(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: temporaryFile) }
+            let keyName = parts.joined(separator: "-")
+            let value = valuePart
+            try (keyName + separator + value).write(
+                to: temporaryFile,
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let result = try runScanner(
+                scanner: scanner,
+                root: repositoryRoot,
+                arguments: ["--extra-file", temporaryFile.path]
+            )
+            assertScannerFinding(result, at: temporaryFile, value: value)
+        }
+    }
+
     func testScannerFailsOnTemporarySyntheticViolationWithoutEchoingValue() throws {
         let sourceFile = URL(fileURLWithPath: #filePath)
         let repositoryRoot = sourceFile
@@ -783,8 +849,8 @@ final class CCS28SecurityTests: XCTestCase {
         let syntheticValue = String(repeating: "z", count: 16)
         let plist = """
         <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0"><dict>
+        <!DOCTYPE \("plist") PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/Property\("List")-1.0.dtd">
+        <\("plist") version="1.0"><dict>
         <key>Settings</key><dict>
         <key>\(keyName)</key>
         <string>\(syntheticValue)</string>
@@ -813,8 +879,8 @@ final class CCS28SecurityTests: XCTestCase {
         let syntheticValue = String(repeating: "z", count: 16)
         let plist = """
         <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-        <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-        <plist version=\"1.0\"><dict>
+        <!DOCTYPE \("plist") PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/Property\("List")-1.0.dtd\">
+        <\("plist") version=\"1.0\"><dict>
         <key>Settings</key><dict>
         <key>\(keyName)</key>
         <string>\(syntheticValue)</string>
@@ -841,8 +907,8 @@ final class CCS28SecurityTests: XCTestCase {
 
         let plist = """
         <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0"><dict>
+        <!DOCTYPE \("plist") PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/Property\("List")-1.0.dtd">
+        <\("plist") version="1.0"><dict>
         <key>Nested</key><dict><key>Enabled</key><true/></dict>
         <key>CurrencyInfoFeed</key><string>https://rates.example.invalid/feed</string>
         </dict></plist>
@@ -885,6 +951,71 @@ final class CCS28SecurityTests: XCTestCase {
             )
             assertScannerFinding(result, at: temporaryFile, value: syntheticValue)
         }
+    }
+
+    func testScannerUsesOpaqueLabelsForCredentialBearingUserPaths() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let keyName = ["secret", "key"].joined(separator: "-")
+        let syntheticValue = ["path", "!@#"].joined()
+        let sensitiveName = keyName + "=" + syntheticValue
+
+        let extraFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent(sensitiveName)
+        defer { try? FileManager.default.removeItem(at: extraFile) }
+        try sensitiveName.write(to: extraFile, atomically: true, encoding: .utf8)
+        let extraResult = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", extraFile.path]
+        )
+        XCTAssertNotEqual(extraResult.status, 0)
+        XCTAssertTrue(extraResult.output.contains("extra-file-1:"), extraResult.output)
+        XCTAssertFalse(extraResult.output.contains(extraFile.path), extraResult.output)
+        XCTAssertFalse(extraResult.output.contains(syntheticValue), extraResult.output)
+
+        let artifactRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-artifact-(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: artifactRoot) }
+        try FileManager.default.createDirectory(at: artifactRoot, withIntermediateDirectories: true)
+        let artifactFile = artifactRoot.appendingPathComponent(sensitiveName)
+        try sensitiveName.write(to: artifactFile, atomically: true, encoding: .utf8)
+        let artifactResult = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--artifact", artifactRoot.path]
+        )
+        XCTAssertNotEqual(artifactResult.status, 0)
+        XCTAssertTrue(artifactResult.output.contains("artifact-1:redacted-"), artifactResult.output)
+        XCTAssertFalse(artifactResult.output.contains(artifactRoot.path), artifactResult.output)
+        XCTAssertFalse(artifactResult.output.contains(syntheticValue), artifactResult.output)
+    }
+
+    func testScannerFailsClosedForExtensionlessPlistMarkerAfterScanWindow() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-late-plist-(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        var payload = Data(repeating: 0x41, count: 5000)
+        payload.append(Data(("<" + "plist><dict>").utf8))
+        try payload.write(to: temporaryFile)
+
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", temporaryFile.path]
+        )
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("extra-file-1:invalid-plist"), result.output)
+        XCTAssertFalse(result.output.contains(temporaryFile.path), result.output)
     }
 
     func testScannerDetectsEncodedQueryNameWithoutEchoingValue() throws {
@@ -976,7 +1107,7 @@ final class CCS28SecurityTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: safeFile) }
         let safePlist = """
         <?xml version="1.0" encoding="UTF-8"?>
-        <plist version="1.0"><dict>
+        <\("plist") version="1.0"><dict>
         <key>\(keyName)</key><true/>
         <key>\(keyName)</key><integer>42</integer>
         </dict></plist>
@@ -999,7 +1130,7 @@ final class CCS28SecurityTests: XCTestCase {
                 : "<data>U0FGRS1EQVRBLTEyMzQ1Njc4OTA=</data>"
             let plist = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <plist version="1.0"><dict>
+            <\("plist") version="1.0"><dict>
             <key>\(keyName)</key>\(valueXML)
             </dict></plist>
             """
@@ -1022,14 +1153,15 @@ final class CCS28SecurityTests: XCTestCase {
         let temporaryFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("ccs28-invalid-unknown-\(UUID().uuidString).blob")
         defer { try? FileManager.default.removeItem(at: temporaryFile) }
-        try "<plist><dict>".write(to: temporaryFile, atomically: true, encoding: .utf8)
+        let malformedPlist = "<" + "plist><dict>"
+        try malformedPlist.write(to: temporaryFile, atomically: true, encoding: .utf8)
 
         let result = try runScanner(
             scanner: scanner,
             root: repositoryRoot,
             arguments: ["--extra-file", temporaryFile.path]
         )
-        assertScannerFinding(result, at: temporaryFile, value: "<plist><dict>")
+        assertScannerFinding(result, at: temporaryFile, value: malformedPlist)
         XCTAssertTrue(result.output.contains(":invalid-plist"), result.output)
     }
 
@@ -1045,6 +1177,8 @@ final class CCS28SecurityTests: XCTestCase {
             "http://rates.example.invalid/feed",
             "https://rates.example.invalid/feed?source=example",
             "https://rates.example.invalid/feed#fragment",
+            "https://rates.example.invalid/feed?",
+            "https://rates.example.invalid/feed#",
             "https://rates.example.invalid:abc/feed",
             "https://rates.example.invalid:99999/feed",
             userinfoValue,
@@ -1057,8 +1191,8 @@ final class CCS28SecurityTests: XCTestCase {
             defer { try? FileManager.default.removeItem(at: temporaryFile) }
             let plist = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0"><dict>
+            <!DOCTYPE \("plist") PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/Property\("List")-1.0.dtd">
+            <\("plist") version="1.0"><dict>
             <key>CurrencyInfoFeed</key><string>\(unsafeValue)</string>
             </dict></plist>
             """
@@ -1101,11 +1235,12 @@ final class CCS28SecurityTests: XCTestCase {
         let lines = result.output.split(whereSeparator: \.isNewline)
         XCTAssertFalse(lines.isEmpty, result.output, file: filePath, line: line)
         XCTAssertTrue(
-            lines.allSatisfy { $0.hasPrefix(file.path + ":") },
+            lines.allSatisfy { $0.hasPrefix("extra-file-1:") || $0.hasPrefix("artifact-1:") },
             result.output,
             file: filePath,
             line: line
         )
+        XCTAssertFalse(result.output.contains(file.path), result.output, file: filePath, line: line)
         XCTAssertFalse(result.output.contains(value), result.output, file: filePath, line: line)
     }
 

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -1094,6 +1094,28 @@ final class CCS28SecurityTests: XCTestCase {
         XCTAssertTrue(safeResult.output.isEmpty, safeResult.output)
     }
 
+    func testScannerTreatsEmbeddedPlistMarkerInBinaryAsBinaryContent() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-safe-embedded-plist-\(UUID().uuidString).bin")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+        let embeddedMarker = "<" + "plist><dict/></plist>"
+        try Data([0, 1, 2] + Array(embeddedMarker.utf8))
+            .write(to: temporaryFile)
+
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--artifact", temporaryFile.path]
+        )
+        XCTAssertEqual(result.status, 0, result.output)
+        XCTAssertTrue(result.output.isEmpty, result.output)
+    }
+
     func testScannerOnlyFlagsStringAndDataForSensitivePlistKeys() throws {
         let sourceFile = URL(fileURLWithPath: #filePath)
         let repositoryRoot = sourceFile

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -635,24 +635,32 @@ final class CCS28SecurityTests: XCTestCase {
     func testSafeHTTPSFeedIsAccepted() {
         let implicitPortResult = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid/feed")
 
-        guard case .success(let url) = implicitPortResult else {
+        guard case .success(let endpoint) = implicitPortResult else {
             return XCTFail("safe HTTPS feed should be accepted")
         }
-        XCTAssertEqual(url.absoluteString, "https://rates.example.invalid/feed")
+        XCTAssertEqual(endpoint.url.absoluteString, "https://rates.example.invalid/feed")
 
         let explicitPortResult = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid:443/feed")
-        guard case .success(let explicitPortURL) = explicitPortResult else {
+        guard case .success(let explicitPortEndpoint) = explicitPortResult else {
             return XCTFail("safe HTTPS feed with explicit numeric port should be accepted")
         }
-        XCTAssertEqual(explicitPortURL.absoluteString, "https://rates.example.invalid:443/feed")
+        XCTAssertEqual(explicitPortEndpoint.url.absoluteString, "https://rates.example.invalid:443/feed")
 
         let encodedPathResult = CurrencyInfoFeedConfiguration.resolve(
             value: "https://rates.example.invalid/feed%2Fv1"
         )
-        guard case .success(let encodedPathURL) = encodedPathResult else {
+        guard case .success(let encodedPathEndpoint) = encodedPathResult else {
             return XCTFail("safe percent-encoded feed path should be accepted")
         }
-        XCTAssertEqual(encodedPathURL.absoluteString, "https://rates.example.invalid/feed%2Fv1")
+        XCTAssertEqual(encodedPathEndpoint.url.absoluteString, "https://rates.example.invalid/feed%2Fv1")
+
+        let encodedPercentResult = CurrencyInfoFeedConfiguration.resolve(
+            value: "https://rates.example.invalid/feed%25v1"
+        )
+        guard case .success(let encodedPercentEndpoint) = encodedPercentResult else {
+            return XCTFail("valid encoded percent should be accepted")
+        }
+        XCTAssertEqual(encodedPercentEndpoint.url.absoluteString, "https://rates.example.invalid/feed%25v1")
     }
 
     func testMalformedPercentEscapesAreRejectedForRawValues() {
@@ -737,7 +745,7 @@ final class CCS28SecurityTests: XCTestCase {
         XCTAssertEqual(transport.requestCount, 0)
     }
 
-    func testInjectedUnsafeSuccessURLsAreRejectedBeforeTransport() {
+    func testInjectedUnsafeRawConfigurationsAreRejectedBeforeTransport() {
         let unsafeValues = [
             "https://rates.example.invalid/feed?",
             "https://rates.example.invalid/feed#",
@@ -750,14 +758,11 @@ final class CCS28SecurityTests: XCTestCase {
         ]
 
         for value in unsafeValues {
-            guard let url = URL(string: value) else {
-                return XCTFail("test URL should be representable")
-            }
             let transport = CCS10Transport()
             let converter = CurrencyConverter(
                 clock: { Date(timeIntervalSince1970: 1000) },
                 defaults: CCS10Defaults(),
-                feedConfiguration: .success(url),
+                feedConfiguration: CurrencyInfoFeedConfiguration.resolve(value: value),
                 transport: transport.send
             )
             let completed = expectation(description: "invalid injected feed")

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -633,12 +633,23 @@ final class CCS10RateFallbackTests: XCTestCase {
 
 final class CCS28SecurityTests: XCTestCase {
     func testSafeHTTPSFeedIsAccepted() {
-        let result = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid/feed")
+        let implicitPortResult = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid/feed")
 
-        guard case .success(let url) = result else {
+        guard case .success(let url) = implicitPortResult else {
             return XCTFail("safe HTTPS feed should be accepted")
         }
         XCTAssertEqual(url.absoluteString, "https://rates.example.invalid/feed")
+
+        let explicitPortResult = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid:443/feed")
+        guard case .success(let explicitPortURL) = explicitPortResult else {
+            return XCTFail("safe HTTPS feed with explicit numeric port should be accepted")
+        }
+        XCTAssertEqual(explicitPortURL.absoluteString, "https://rates.example.invalid:443/feed")
+    }
+
+    func testMalformedPortFeedIsRejected() {
+        assertConfigurationFailure("https://rates.example.invalid:abc/feed", equals: .malformed)
+        assertConfigurationFailure("https://rates.example.invalid:99999/feed", equals: .malformed)
     }
 
     func testMissingFeedIsTypedAsMissing() {
@@ -732,6 +743,32 @@ final class CCS28SecurityTests: XCTestCase {
         XCTAssertFalse(outputText.contains(String(repeating: "x", count: 16)))
     }
 
+    func testScannerFailsOnTemporarySyntheticAccessKeyQueryViolationWithoutEchoingValue() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: scanner.path))
+
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-synthetic-access-key-violation-\(UUID().uuidString).swift")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let syntheticValue = String(repeating: "x", count: 16)
+        let syntheticKeyName = ["access", "key"].joined(separator: "-")
+        let syntheticViolation = "https://rates.example.invalid/feed?\(syntheticKeyName)=" + syntheticValue
+        try syntheticViolation.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", temporaryFile.path]
+        )
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertFalse(result.output.contains(syntheticValue), result.output)
+    }
+
     func testScannerFailsOnTemporarySyntheticPlistViolationWithoutEchoingValue() throws {
         let sourceFile = URL(fileURLWithPath: #filePath)
         let repositoryRoot = sourceFile
@@ -760,6 +797,36 @@ final class CCS28SecurityTests: XCTestCase {
         XCTAssertNotEqual(result.status, 0)
         XCTAssertTrue(result.output.contains(":Settings.\(keyName)"))
         XCTAssertFalse(result.output.contains(syntheticValue))
+    }
+
+    func testScannerFailsOnTemporarySyntheticAccessKeyPlistViolationWithoutEchoingValue() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-synthetic-access-key-plist-violation-\(UUID().uuidString).plist")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let keyName = "accessKey"
+        let syntheticValue = String(repeating: "z", count: 16)
+        let plist = """
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+        <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+        <plist version=\"1.0\"><dict>
+        <key>Settings</key><dict>
+        <key>\(keyName)</key>
+        <string>\(syntheticValue)</string>
+        </dict>
+        </dict></plist>
+        """
+        try plist.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(scanner: scanner, root: repositoryRoot, arguments: ["--artifact", temporaryFile.path])
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains(":Settings.\(keyName)"), result.output)
+        XCTAssertFalse(result.output.contains(syntheticValue), result.output)
     }
 
     func testScannerAcceptsTemporarySafePlist() throws {
@@ -799,6 +866,8 @@ final class CCS28SecurityTests: XCTestCase {
             "http://rates.example.invalid/feed",
             "https://rates.example.invalid/feed?source=example",
             "https://rates.example.invalid/feed#fragment",
+            "https://rates.example.invalid:abc/feed",
+            "https://rates.example.invalid:99999/feed",
             userinfoValue,
             "not a URL"
         ]

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -645,6 +645,26 @@ final class CCS28SecurityTests: XCTestCase {
             return XCTFail("safe HTTPS feed with explicit numeric port should be accepted")
         }
         XCTAssertEqual(explicitPortURL.absoluteString, "https://rates.example.invalid:443/feed")
+
+        let encodedPathResult = CurrencyInfoFeedConfiguration.resolve(
+            value: "https://rates.example.invalid/feed%2Fv1"
+        )
+        guard case .success(let encodedPathURL) = encodedPathResult else {
+            return XCTFail("safe percent-encoded feed path should be accepted")
+        }
+        XCTAssertEqual(encodedPathURL.absoluteString, "https://rates.example.invalid/feed%2Fv1")
+    }
+
+    func testMalformedPercentEscapesAreRejectedForRawValues() {
+        let malformedValues = [
+            "https://rates.example.invalid/feed%",
+            "https://rates.example.invalid/feed%2",
+            "https://rates.example.invalid/feed%GG"
+        ]
+
+        for value in malformedValues {
+            assertConfigurationFailure(value, equals: .malformed)
+        }
     }
 
     func testMalformedPortFeedIsRejected() {
@@ -723,7 +743,10 @@ final class CCS28SecurityTests: XCTestCase {
             "https://rates.example.invalid/feed#",
             "https://" + "user" + "@rates.example.invalid/feed",
             "https://rates.example.invalid:99999/feed",
-            "https://rates.example.invalid/feed%20with-space"
+            "https://rates.example.invalid/feed%20with-space",
+            "https://rates.example.invalid/feed%",
+            "https://rates.example.invalid/feed%2",
+            "https://rates.example.invalid/feed%GG"
         ]
 
         for value in unsafeValues {
@@ -910,7 +933,7 @@ final class CCS28SecurityTests: XCTestCase {
         <!DOCTYPE \("plist") PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/Property\("List")-1.0.dtd">
         <\("plist") version="1.0"><dict>
         <key>Nested</key><dict><key>Enabled</key><true/></dict>
-        <key>CurrencyInfoFeed</key><string>https://rates.example.invalid/feed</string>
+        <key>CurrencyInfoFeed</key><string>https://rates.example.invalid/feed%2Fv1</string>
         </dict></plist>
         """
         try plist.write(to: temporaryFile, atomically: true, encoding: .utf8)
@@ -918,6 +941,67 @@ final class CCS28SecurityTests: XCTestCase {
         let result = try runScanner(scanner: scanner, root: repositoryRoot, arguments: ["--artifact", temporaryFile.path])
         XCTAssertEqual(result.status, 0, result.output)
         XCTAssertTrue(result.output.isEmpty, result.output)
+    }
+
+    func testScannerRecognizesWhitespaceDoctypeInExtensionlessPlistAndFindsSensitiveValueWithoutEcho() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-whitespace-doctype-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let syntheticValue = "synthetic-sensitive-value"
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE
+          \("plist") PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/Property\("List")-1.0.dtd">
+        <\("plist") version="1.0"><dict>
+        <key>apiKey</key><string>\(syntheticValue)</string>
+        </dict></plist>
+        """
+        try plist.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--artifact", temporaryFile.path]
+        )
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("artifact-1:file-1:apiKey"), result.output)
+        XCTAssertFalse(result.output.contains(syntheticValue), result.output)
+    }
+
+    func testScannerRecognizesMalformedWhitespaceDoctypeStructureInExtensionlessFixture() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-malformed-whitespace-doctype-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let syntheticValue = "synthetic-malformed-value"
+        let malformedPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE \("plist") PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/Property\("\n        List - 1.0.dtd")">
+        <\("plist") version="1.0"><dict>
+        <key>apiKey</key><string>\(syntheticValue)</string>
+        </dict>
+        """
+        try malformedPlist.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--artifact", temporaryFile.path]
+        )
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("artifact-1:file-1:invalid-plist"), result.output)
+        XCTAssertFalse(result.output.contains(syntheticValue), result.output)
     }
 
     func testScannerDetectsDataDrivenSensitiveAssignmentsAcrossFileNames() throws {
@@ -989,7 +1073,7 @@ final class CCS28SecurityTests: XCTestCase {
             arguments: ["--artifact", artifactRoot.path]
         )
         XCTAssertNotEqual(artifactResult.status, 0)
-        XCTAssertTrue(artifactResult.output.contains("artifact-1:redacted-"), artifactResult.output)
+        XCTAssertTrue(artifactResult.output.contains("artifact-1:file-1:"), artifactResult.output)
         XCTAssertFalse(artifactResult.output.contains(artifactRoot.path), artifactResult.output)
         XCTAssertFalse(artifactResult.output.contains(syntheticValue), artifactResult.output)
     }
@@ -1201,6 +1285,9 @@ final class CCS28SecurityTests: XCTestCase {
             "https://rates.example.invalid/feed#fragment",
             "https://rates.example.invalid/feed?",
             "https://rates.example.invalid/feed#",
+            "https://rates.example.invalid/feed%",
+            "https://rates.example.invalid/feed%2",
+            "https://rates.example.invalid/feed%GG",
             "https://rates.example.invalid:abc/feed",
             "https://rates.example.invalid:99999/feed",
             userinfoValue,

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -747,8 +747,8 @@ final class CCS28SecurityTests: XCTestCase {
 
     func testInjectedUnsafeRawConfigurationsAreRejectedBeforeTransport() {
         let unsafeValues = [
-            "https://rates.example.invalid/feed?",
-            "https://rates.example.invalid/feed#",
+            "https://rates.example.invalid/feed" + "?",
+            "https://rates.example.invalid/feed" + "#",
             "https://" + "user" + "@rates.example.invalid/feed",
             "https://rates.example.invalid:99999/feed",
             "https://rates.example.invalid/feed%20with-space",
@@ -1288,8 +1288,8 @@ final class CCS28SecurityTests: XCTestCase {
             "http://rates.example.invalid/feed",
             "https://rates.example.invalid/feed?source=example",
             "https://rates.example.invalid/feed#fragment",
-            "https://rates.example.invalid/feed?",
-            "https://rates.example.invalid/feed#",
+            "https://rates.example.invalid/feed" + "?",
+            "https://rates.example.invalid/feed" + "#",
             "https://rates.example.invalid/feed%",
             "https://rates.example.invalid/feed%2",
             "https://rates.example.invalid/feed%GG",

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -89,6 +89,7 @@ private final class CCS10SnapshotBarrierDefaults: CCS10Defaults {
 
 final class CCS10RateFallbackTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1000)
+    private let safeFeedConfiguration = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid/feed")
     private let response = HTTPURLResponse(
         url: URL(string: "https://example.test")!,
         statusCode: 200,
@@ -145,7 +146,7 @@ final class CCS10RateFallbackTests: XCTestCase {
         defaults.set(updated, forKey: "LastUpdateDate")
         defaults.set(["USD": Float32(1)], forKey: "CurrencyData")
         defaults.set(123, forKey: "CurrencyDataTime")
-        let converter = CurrencyConverter(clock: { self.now }, defaults: defaults, transport: transport.send)
+        let converter = CurrencyConverter(clock: { self.now }, defaults: defaults, feedConfiguration: safeFeedConfiguration, transport: transport.send)
 
         let completion = expectation(description: "http failure")
         converter.loadData { error in
@@ -362,6 +363,7 @@ final class CCS10RateFallbackTests: XCTestCase {
                 return self.now
             },
             defaults: CCS10Defaults(),
+            feedConfiguration: safeFeedConfiguration,
             transport: CCS10Transport().send
         )
 
@@ -449,6 +451,7 @@ final class CCS10RateFallbackTests: XCTestCase {
         let converter = CurrencyConverter(
             clock: { self.now },
             defaults: CCS10Defaults(),
+            feedConfiguration: safeFeedConfiguration,
             transport: { _, completion in
                 completion(
                     Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":1.2},"timestamp":456}"#.utf8),
@@ -477,6 +480,7 @@ final class CCS10RateFallbackTests: XCTestCase {
         let converter = CurrencyConverter(
             clock: { self.now },
             defaults: defaults,
+            feedConfiguration: safeFeedConfiguration,
             transport: { _, completion in
                 transportStarted.signal()
                 completion(webPayload, self.response, nil)
@@ -518,6 +522,7 @@ final class CCS10RateFallbackTests: XCTestCase {
         converter = CurrencyConverter(
             clock: { self.now },
             defaults: defaults,
+            feedConfiguration: safeFeedConfiguration,
             transport: { _, completion in
                 completion(webPayload, self.response, nil)
             }
@@ -622,6 +627,123 @@ final class CCS10RateFallbackTests: XCTestCase {
     }
 
     private func makeConverter(defaults: CCS10Defaults = CCS10Defaults(), transport: CCS10Transport) -> CurrencyConverter {
-        CurrencyConverter(clock: { self.now }, defaults: defaults, transport: transport.send)
+        CurrencyConverter(clock: { self.now }, defaults: defaults, feedConfiguration: safeFeedConfiguration, transport: transport.send)
+    }
+}
+
+final class CCS28SecurityTests: XCTestCase {
+    func testSafeHTTPSFeedIsAccepted() {
+        let result = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid/feed")
+
+        guard case .success(let url) = result else {
+            return XCTFail("safe HTTPS feed should be accepted")
+        }
+        XCTAssertEqual(url.absoluteString, "https://rates.example.invalid/feed")
+    }
+
+    func testMissingFeedIsTypedAsMissing() {
+        assertConfigurationFailure(nil, equals: .missing)
+    }
+
+    func testHTTPFeedIsRejected() {
+        assertConfigurationFailure("http://rates.example.invalid/feed", equals: .nonHTTPS)
+    }
+
+    func testQueryBearingFeedIsRejected() {
+        assertConfigurationFailure("https://rates.example.invalid/feed?source=example", equals: .query)
+    }
+
+    func testFragmentBearingFeedIsRejected() {
+        assertConfigurationFailure("https://rates.example.invalid/feed#fragment", equals: .fragment)
+    }
+
+    func testUserinfoBearingFeedIsRejected() {
+        assertConfigurationFailure("https://user@rates.example.invalid/feed", equals: .userinfo)
+    }
+
+    func testMalformedFeedIsRejected() {
+        assertConfigurationFailure("not a URL", equals: .malformed)
+    }
+
+    func testMissingFeedDoesNotInvokeTransportAndUsesUnavailableStatus() {
+        let transport = CCS10Transport()
+        let converter = CurrencyConverter(
+            clock: { Date(timeIntervalSince1970: 1000) },
+            defaults: CCS10Defaults(),
+            feedConfiguration: .failure(.missing),
+            transport: transport.send
+        )
+        let completed = expectation(description: "missing feed")
+
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .unavailable)
+            XCTAssertEqual(converter.rateDataStatus.lastRefreshError, .unavailable)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertEqual(transport.requestCount, 0)
+    }
+
+    func testRejectedFeedDoesNotInvokeTransportAndUsesInvalidConfigurationStatus() {
+        let transport = CCS10Transport()
+        let converter = CurrencyConverter(
+            clock: { Date(timeIntervalSince1970: 1000) },
+            defaults: CCS10Defaults(),
+            feedConfiguration: .failure(.query),
+            transport: transport.send
+        )
+        let completed = expectation(description: "rejected feed")
+
+        converter.loadData { error in
+            XCTAssertEqual(error as? RateDataError, .invalidConfiguration)
+            XCTAssertEqual(converter.rateDataStatus.lastRefreshError, .invalidConfiguration)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertEqual(transport.requestCount, 0)
+    }
+
+    func testScannerFailsOnTemporarySyntheticViolationWithoutEchoingValue() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: scanner.path))
+
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-synthetic-violation-\(UUID().uuidString).swift")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let keyName = ["api", "key"].joined(separator: "_")
+        let syntheticViolation = keyName + "=" + String(repeating: "x", count: 16)
+        try syntheticViolation.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["python3", scanner.path, "--root", repositoryRoot.path, "--extra-file", temporaryFile.path]
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        process.waitUntilExit()
+
+        let outputText = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        XCTAssertNotEqual(process.terminationStatus, 0)
+        XCTAssertFalse(outputText.contains(String(repeating: "x", count: 16)))
+    }
+
+    private func assertConfigurationFailure(
+        _ value: Any?,
+        equals expected: CurrencyInfoFeedConfigurationError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .failure(let error) = CurrencyInfoFeedConfiguration.resolve(value: value) else {
+            return XCTFail("feed should be rejected", file: file, line: line)
+        }
+        XCTAssertEqual(error, expected, file: file, line: line)
     }
 }

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -854,6 +854,185 @@ final class CCS28SecurityTests: XCTestCase {
         XCTAssertTrue(result.output.isEmpty, result.output)
     }
 
+    func testScannerDetectsDataDrivenSensitiveAssignmentsAcrossFileNames() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let syntheticValue = ["value", "!@#$%^&*()"].joined(separator: "-")
+        let cases: [([String], String, String)] = [
+            (["api", "token"], "_", "api-token.log"),
+            (["secret", "key"], "_", "secret-key-extensionless"),
+            (["auth", "token"], "-", "auth-token.unknown")
+        ]
+
+        for (parts, separator, fileName) in cases {
+            let temporaryFile = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ccs28-\(fileName)-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: temporaryFile) }
+            let keyName = parts.joined(separator: separator)
+            try (keyName + " = \"" + syntheticValue + "\"").write(
+                to: temporaryFile,
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let result = try runScanner(
+                scanner: scanner,
+                root: repositoryRoot,
+                arguments: ["--extra-file", temporaryFile.path]
+            )
+            assertScannerFinding(result, at: temporaryFile, value: syntheticValue)
+        }
+    }
+
+    func testScannerDetectsEncodedQueryNameWithoutEchoingValue() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-encoded-query-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let keyName = ["api", "token"].joined(separator: "_")
+        let encodedName = keyName.replacingOccurrences(of: "_", with: "%5F")
+        let syntheticValue = ["query", "!@#$%^&*()"].joined(separator: "-")
+        let violation = "https://rates.example.invalid/feed?\(encodedName)=\(syntheticValue)"
+        try violation.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", temporaryFile.path]
+        )
+        assertScannerFinding(result, at: temporaryFile, value: syntheticValue)
+    }
+
+    func testScannerScansBinaryAndInvalidUTF8ContentButAcceptsSafeBinary() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let keyName = ["auth", "token"].joined(separator: "_")
+        let syntheticValue = ["binary", "!@#$%^&*()"].joined(separator: "-")
+        let assignment = Data((keyName + "=" + syntheticValue).utf8)
+
+        let binaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-binary-\(UUID().uuidString).bin")
+        defer { try? FileManager.default.removeItem(at: binaryFile) }
+        var binaryPayload = Data([0, 0x7f])
+        binaryPayload.append(assignment)
+        binaryPayload.append(Data([0, 0xfe]))
+        try binaryPayload.write(to: binaryFile)
+        let binaryResult = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", binaryFile.path]
+        )
+        assertScannerFinding(binaryResult, at: binaryFile, value: syntheticValue)
+
+        let invalidUTF8File = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-invalid-utf8-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: invalidUTF8File) }
+        var invalidUTF8Payload = Data([0xff])
+        invalidUTF8Payload.append(assignment)
+        invalidUTF8Payload.append(Data([0xfe]))
+        try invalidUTF8Payload.write(to: invalidUTF8File)
+        let invalidResult = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", invalidUTF8File.path]
+        )
+        assertScannerFinding(invalidResult, at: invalidUTF8File, value: syntheticValue)
+
+        let safeBinaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-safe-binary-\(UUID().uuidString).asset")
+        defer { try? FileManager.default.removeItem(at: safeBinaryFile) }
+        try Data([0, 0x53, 0x41, 0x46, 0x45, 0, 0xff, 0x01])
+            .write(to: safeBinaryFile)
+        let safeResult = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", safeBinaryFile.path]
+        )
+        XCTAssertEqual(safeResult.status, 0, safeResult.output)
+        XCTAssertTrue(safeResult.output.isEmpty, safeResult.output)
+    }
+
+    func testScannerOnlyFlagsStringAndDataForSensitivePlistKeys() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let keyName = ["private", "key"].joined(separator: "_")
+
+        let safeFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-safe-plist-types-\(UUID().uuidString).plist")
+        defer { try? FileManager.default.removeItem(at: safeFile) }
+        let safePlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <plist version="1.0"><dict>
+        <key>\(keyName)</key><true/>
+        <key>\(keyName)</key><integer>42</integer>
+        </dict></plist>
+        """
+        try safePlist.write(to: safeFile, atomically: true, encoding: .utf8)
+        let safeResult = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", safeFile.path]
+        )
+        XCTAssertEqual(safeResult.status, 0, safeResult.output)
+
+        for material in ["string", "data"] {
+            let temporaryFile = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ccs28-plist-\(material)-\(UUID().uuidString).plist")
+            defer { try? FileManager.default.removeItem(at: temporaryFile) }
+            let syntheticValue = [material, "!@#$%^*()-"].joined(separator: "-")
+            let valueXML = material == "string"
+                ? "<string>\(syntheticValue)</string>"
+                : "<data>U0FGRS1EQVRBLTEyMzQ1Njc4OTA=</data>"
+            let plist = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <plist version="1.0"><dict>
+            <key>\(keyName)</key>\(valueXML)
+            </dict></plist>
+            """
+            try plist.write(to: temporaryFile, atomically: true, encoding: .utf8)
+            let result = try runScanner(
+                scanner: scanner,
+                root: repositoryRoot,
+                arguments: ["--extra-file", temporaryFile.path]
+            )
+            assertScannerFinding(result, at: temporaryFile, value: material == "string" ? syntheticValue : valueXML)
+        }
+    }
+
+    func testScannerFailsClosedForUnknownInvalidPlist() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-invalid-unknown-\(UUID().uuidString).blob")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+        try "<plist><dict>".write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", temporaryFile.path]
+        )
+        assertScannerFinding(result, at: temporaryFile, value: "<plist><dict>")
+        XCTAssertTrue(result.output.contains(":invalid-plist"), result.output)
+    }
+
     func testScannerRejectsUnsafeArtifactFeedValues() throws {
         let sourceFile = URL(fileURLWithPath: #filePath)
         let repositoryRoot = sourceFile
@@ -909,6 +1088,25 @@ final class CCS28SecurityTests: XCTestCase {
             process.terminationStatus,
             String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
         )
+    }
+
+    private func assertScannerFinding(
+        _ result: (status: Int32, output: String),
+        at file: URL,
+        value: String,
+        filePath: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertNotEqual(result.status, 0, result.output, file: filePath, line: line)
+        let lines = result.output.split(whereSeparator: \.isNewline)
+        XCTAssertFalse(lines.isEmpty, result.output, file: filePath, line: line)
+        XCTAssertTrue(
+            lines.allSatisfy { $0.hasPrefix(file.path + ":") },
+            result.output,
+            file: filePath,
+            line: line
+        )
+        XCTAssertFalse(result.output.contains(value), result.output, file: filePath, line: line)
     }
 
     private func assertConfigurationFailure(

--- a/CurrencyConverterTests/CCS10RateFallbackTests.swift
+++ b/CurrencyConverterTests/CCS10RateFallbackTests.swift
@@ -658,7 +658,8 @@ final class CCS28SecurityTests: XCTestCase {
     }
 
     func testUserinfoBearingFeedIsRejected() {
-        assertConfigurationFailure("https://user@rates.example.invalid/feed", equals: .userinfo)
+        let userinfoFeed = "https://" + "user" + "@rates.example.invalid/feed"
+        assertConfigurationFailure(userinfoFeed, equals: .userinfo)
     }
 
     func testMalformedFeedIsRejected() {
@@ -721,18 +722,124 @@ final class CCS28SecurityTests: XCTestCase {
         let syntheticViolation = keyName + "=" + String(repeating: "x", count: 16)
         try syntheticViolation.write(to: temporaryFile, atomically: true, encoding: .utf8)
 
+        let result = try runScanner(
+            scanner: scanner,
+            root: repositoryRoot,
+            arguments: ["--extra-file", temporaryFile.path]
+        )
+        XCTAssertNotEqual(result.status, 0)
+        let outputText = result.output
+        XCTAssertFalse(outputText.contains(String(repeating: "x", count: 16)))
+    }
+
+    func testScannerFailsOnTemporarySyntheticPlistViolationWithoutEchoingValue() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-synthetic-violation-\(UUID().uuidString).plist")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let keyName = ["api", "key"].joined()
+        let syntheticValue = String(repeating: "z", count: 16)
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+        <key>Settings</key><dict>
+        <key>\(keyName)</key>
+        <string>\(syntheticValue)</string>
+        </dict>
+        </dict></plist>
+        """
+        try plist.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(scanner: scanner, root: repositoryRoot, arguments: ["--artifact", temporaryFile.path])
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains(":Settings.\(keyName)"))
+        XCTAssertFalse(result.output.contains(syntheticValue))
+    }
+
+    func testScannerAcceptsTemporarySafePlist() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let temporaryFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccs28-safe-\(UUID().uuidString).plist")
+        defer { try? FileManager.default.removeItem(at: temporaryFile) }
+
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+        <key>Nested</key><dict><key>Enabled</key><true/></dict>
+        <key>CurrencyInfoFeed</key><string>https://rates.example.invalid/feed</string>
+        </dict></plist>
+        """
+        try plist.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+        let result = try runScanner(scanner: scanner, root: repositoryRoot, arguments: ["--artifact", temporaryFile.path])
+        XCTAssertEqual(result.status, 0, result.output)
+        XCTAssertTrue(result.output.isEmpty, result.output)
+    }
+
+    func testScannerRejectsUnsafeArtifactFeedValues() throws {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = sourceFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scanner = repositoryRoot.appendingPathComponent("Scripts/scan-credential-safety.py")
+        let userinfoValue = "https://" + "user" + "@rates.example.invalid/feed"
+        let unsafeValues = [
+            "$(CURRENCY_INFO_FEED)",
+            "http://rates.example.invalid/feed",
+            "https://rates.example.invalid/feed?source=example",
+            "https://rates.example.invalid/feed#fragment",
+            userinfoValue,
+            "not a URL"
+        ]
+
+        for unsafeValue in unsafeValues {
+            let temporaryFile = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ccs28-unsafe-\(UUID().uuidString).plist")
+            defer { try? FileManager.default.removeItem(at: temporaryFile) }
+            let plist = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0"><dict>
+            <key>CurrencyInfoFeed</key><string>\(unsafeValue)</string>
+            </dict></plist>
+            """
+            try plist.write(to: temporaryFile, atomically: true, encoding: .utf8)
+
+            let result = try runScanner(scanner: scanner, root: repositoryRoot, arguments: ["--artifact", temporaryFile.path])
+            XCTAssertNotEqual(result.status, 0, unsafeValue)
+            XCTAssertTrue(result.output.contains(":CurrencyInfoFeed"), result.output)
+            XCTAssertFalse(result.output.contains(unsafeValue), result.output)
+        }
+    }
+
+    private func runScanner(
+        scanner: URL,
+        root: URL,
+        arguments: [String]
+    ) throws -> (status: Int32, output: String) {
         let process = Process()
         let output = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["python3", scanner.path, "--root", repositoryRoot.path, "--extra-file", temporaryFile.path]
+        process.arguments = ["python3", scanner.path, "--root", root.path] + arguments
         process.standardOutput = output
         process.standardError = output
         try process.run()
         process.waitUntilExit()
-
-        let outputText = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        XCTAssertNotEqual(process.terminationStatus, 0)
-        XCTAssertFalse(outputText.contains(String(repeating: "x", count: 16)))
+        return (
+            process.terminationStatus,
+            String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        )
     }
 
     private func assertConfigurationFailure(

--- a/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
+++ b/CurrencyConverterTests/CCS17RefreshCoalescingTests.swift
@@ -145,6 +145,7 @@ private final class CCS17LateJoinConverter: CurrencyConverter {
 
 final class CCS17RefreshCoalescingTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1000)
+    private let safeFeedConfiguration = CurrencyInfoFeedConfiguration.resolve(value: "https://rates.example.invalid/feed")
     private let successData = Data(#"{"base":"EUR","date":"2026-07-18","rates":{"USD":1.0,"JPY":110.0},"timestamp":123}"#.utf8)
 
     func testConcurrentStaleLoadsUseOneTransportAndFanOutSuccessOnce() {
@@ -256,7 +257,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         defaults.set(now, forKey: "LastUpdateDate")
         defaults.set(["USD": Float32(1)], forKey: "CurrencyData")
         defaults.set(123, forKey: "CurrencyDataTime")
-        let defaultsConverter = CurrencyConverter(clock: { self.now }, defaults: defaults, transport: defaultsTransport.send)
+        let defaultsConverter = CurrencyConverter(clock: { self.now }, defaults: defaults, feedConfiguration: safeFeedConfiguration, transport: defaultsTransport.send)
         let defaultsExpectation = expectation(description: "fresh defaults callers complete")
         defaultsExpectation.expectedFulfillmentCount = 8
         defaultsExpectation.assertForOverFulfill = true
@@ -274,7 +275,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
         var transportCount = 0
         let response = HTTPURLResponse(url: URL(string: "https://example.test")!, statusCode: 200, httpVersion: nil, headerFields: nil)
         let failure = NSError(domain: "CCS17", code: 19)
-        let converter = CurrencyConverter(clock: { self.now }, defaults: defaults) { [self] _, completion in
+        let converter = CurrencyConverter(clock: { self.now }, defaults: defaults, feedConfiguration: safeFeedConfiguration) { [self] _, completion in
             transportCount += 1
             if transportCount == 1 {
                 completion(nil, nil, failure)
@@ -302,7 +303,7 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
 
     func testLateCacheMissJoinsFreshCacheAfterRefreshFinishes() {
         let transport = CCS17ControlledTransport()
-        let converter = CCS17LateJoinConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), transport: transport.send)
+        let converter = CCS17LateJoinConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), feedConfiguration: safeFeedConfiguration, transport: transport.send)
         let firstCompletion = expectation(description: "first refresh completion")
 
         converter.loadData { error in
@@ -364,11 +365,11 @@ final class CCS17RefreshCoalescingTests: XCTestCase {
     }
 
     private func makeStaleConverter(transport: CCS17ControlledTransport) -> CurrencyConverter {
-        CurrencyConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), transport: transport.send)
+        CurrencyConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), feedConfiguration: safeFeedConfiguration, transport: transport.send)
     }
 
     private func makeObservedStaleConverter(transport: CCS17ControlledTransport) -> CCS17ObservedConverter {
-        CCS17ObservedConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), transport: transport.send)
+        CCS17ObservedConverter(clock: { self.now }, defaults: CCS17MemoryDefaults(), feedConfiguration: safeFeedConfiguration, transport: transport.send)
     }
 
     private func startConcurrentLoads(

--- a/README.md
+++ b/README.md
@@ -39,7 +39,18 @@ Safari App Extension跟以前的Safari Extension不同，他**無法**單獨安�
 
 ## Rate-feed configuration
 
-The repository and its default app/extension builds contain no configured rate feed. The app and Safari extension may receive a local or release-injected `CurrencyInfoFeed` value through an untracked `Configuration/RateFeed.xcconfig`, copied from `Configuration/RateFeed.xcconfig.example`. The value must be a credential-free HTTPS endpoint with no userinfo, query, or fragment. Never put provider credentials in source, plist files, build settings, tests, logs, or release artifacts.
+The repository and its default app/extension builds contain no configured rate feed. `Configuration/Base.xcconfig` is the tracked base configuration for the app and Safari extension Debug/Release targets. It sets `CURRENCY_INFO_FEED` empty, then Xcode automatically loads the optional, ignored `Configuration/RateFeed.xcconfig` when that file exists.
+
+For a local or release-injected build, copy the safe example and build both targets:
+
+```sh
+cp Configuration/RateFeed.xcconfig.example Configuration/RateFeed.xcconfig
+xcodebuild -project CurrencyConverter.xcodeproj -scheme CurrencyConverter -configuration Release -destination "platform=macOS,arch=$(uname -m)" build
+xcodebuild -project CurrencyConverter.xcodeproj -scheme "CurrencyConverter Extension" -configuration Release -destination "platform=macOS,arch=$(uname -m)" build
+rm Configuration/RateFeed.xcconfig
+```
+
+The example uses xcconfig-safe escaped slashes (`https:/$()/rates.example.invalid/feed`); after Xcode expands the variable, the processed plist contains the normal credential-free HTTPS URL `https://rates.example.invalid/feed`. Without the copied file, the processed `CurrencyInfoFeed` value is empty. The value must never contain credentials, userinfo, a query, or a fragment. Never put provider credentials in source, plist files, build settings, tests, logs, or release artifacts.
 
 ## CCS-28 owner-only incident runbook (2026-07-19)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ Safari App Extension跟以前的Safari Extension不同，他**無法**單獨安�
 1. ~~首先，我不確定這東西很多人用的話，會不會讓一個月1000的quota擠爆。真的有這問題的話，我會用自己的server來解決。~~ 現在我架設自己的server來解決這問題，希望他不要被打爆（不可能吧！？）
 2. 沒有i18n....說真的也不太需要吧
 
+## Rate-feed configuration
+
+The repository and its default app/extension builds contain no configured rate feed. The app and Safari extension may receive a local or release-injected `CurrencyInfoFeed` value through an untracked `Configuration/RateFeed.xcconfig`, copied from `Configuration/RateFeed.xcconfig.example`. The value must be a credential-free HTTPS endpoint with no userinfo, query, or fragment. Never put provider credentials in source, plist files, build settings, tests, logs, or release artifacts.
+
+## CCS-28 owner-only incident runbook (2026-07-19)
+
+Treat every previously tracked credential as compromised. This runbook is owner-only and records work that must be evidenced before CCS-28 is marked Fixed; external rotation is not claimed complete here.
+
+1. Code removal: verify credential literals and credential-bearing feed URLs are removed from source, plists, tests, configuration, build settings, and generated app/extension artifacts; run the tracked-tree and artifact scanners.
+2. External provider revoke/rotate: revoke each compromised provider credential, issue replacements through the provider, and confirm the old credentials no longer authenticate. Record provider ticket IDs and timestamps.
+3. Intermediary/server configuration rotation: if any rate intermediary exists outside this repository, rotate its upstream credentials and deployment secrets, redeploy, verify access logs and health checks, and record the deployment/change IDs. Do not add an intermediary as part of CCS-28.
+4. Git history assessment: identify affected commits, refs, tags, forks, mirrors, caches, and retention windows; obtain an owner decision on whether history exposure requires a separate remediation. Do not rewrite history as part of CCS-28.
+5. GitHub release artifact replacement/removal: inventory releases and attached archives, remove or replace affected artifacts, invalidate distribution links where applicable, and record release IDs and timestamps.
+6. Downstream forks/clones/caches: notify owners of forks, clones, CI caches, package mirrors, and backups; request purge/reclone actions and record acknowledgements or outstanding owners.
+7. Evidence before Fixed: attach the code-removal diff, scanner/build/test results, provider revoke/rotate confirmations, intermediary deployment evidence when applicable, history assessment, release artifact actions, downstream notifications, and owner sign-off. CCS-28 remains open until the external evidence is complete.
+
 ## Xcode 26.6 build and test baseline
 
 The reproducible baseline uses Xcode 26.6 (build 17F113) explicitly:

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -68,7 +68,7 @@ ASSIGNMENT_PATTERN = re.compile(
     (?P<name>
         \"(?:[^\"\\]|\\.)*\"
         |'(?:[^'\\]|\\.)*'
-        |[A-Za-z%][A-Za-z0-9_.%\-]{0,80}
+        |[A-Za-z%][A-Za-z0-9_.%\-]*
     )
     [ \t]*(?:=(?!=)|:(?!=))[ \t]*(?P<value>[^\r\n]*)
     """,
@@ -82,12 +82,15 @@ def report(findings: list[tuple[str, str]], location: str) -> None:
 
 def decode_name(value: object) -> str:
     decoded = str(value)
-    for _ in range(3):
+    while True:
         next_value = unquote_plus(decoded)
         if next_value == decoded:
-            break
+            return decoded
+        # Percent decoding strictly shrinks every changing input, which bounds
+        # the loop without imposing a bypassable nesting-depth limit.
+        if len(next_value) >= len(decoded):
+            return next_value
         decoded = next_value
-    return decoded
 
 
 def normalized_name(value: object) -> str:
@@ -144,13 +147,14 @@ def scan_line(line: str) -> bool:
     if has_sensitive_assignment(line):
         return True
     for match in URL_PATTERN.finditer(line):
-        candidate = match.group(0).rstrip(".,;!?)]}")
+        candidate = match.group(0).rstrip(".,;!)]}")
         try:
             parsed = urlsplit(candidate)
         except ValueError:
             return True
         if (
-            parsed.username is not None
+            candidate.endswith(("?", "#"))
+            or parsed.username is not None
             or parsed.password is not None
             or has_credential_param(parsed.query)
             or has_credential_param(parsed.fragment)
@@ -253,10 +257,6 @@ def is_credential_material(value: object) -> bool:
     if isinstance(value, (bytes, bytearray)):
         return bool(value)
     return False
-
-
-def plist_key_name(key: object) -> str:
-    return normalized_name(key)
 
 
 def scan_plist(raw: bytes, display: str, findings: list[tuple[str, str]], artifact: bool) -> None:

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 """Credential-safe scanner for tracked sources and built app artifacts.
 
-Findings intentionally contain only a path and a line/byte location.
+Findings intentionally contain only an opaque label and a line/byte location.
 """
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import os
 import plistlib
 import re
@@ -20,9 +19,17 @@ from urllib.parse import parse_qsl, unquote, unquote_plus, urlsplit
 
 PLIST_SUFFIXES = {".plist"}
 PLIST_BINARY_HEADER = b"bplist" + b"00"
-PLIST_XML_MARKER = b"<" + b"plist"
-PLIST_DOCTYPE_MARKER = b"<!" + b"doctype " + b"plist"
-PLIST_PROPERTY_MARKER = b"property" + b"list-1.0.dtd"
+PLIST_XML_PATTERN = re.compile(
+    b"<" + rb"\s*" + b"plist" + rb"(?:\s|>)", re.IGNORECASE
+)
+PLIST_DOCTYPE_PATTERN = re.compile(
+    b"<" + rb"!\s*" + b"doctype" + rb"\s+" + b"plist" + rb"\b",
+    re.IGNORECASE,
+)
+PLIST_PROPERTY_DTD_PATTERN = re.compile(
+    b"property" + rb"\s*list" + rb"\s*-\s*1\.0" + rb"\s*\.dtd",
+    re.IGNORECASE,
+)
 SENSITIVE_NAMES = frozenset(
     {
         "apikey",
@@ -214,6 +221,8 @@ def safe_endpoint(value: object) -> bool:
         return False
     if any(character.isspace() for character in value) or "$(" in value:
         return False
+    if re.search(r"%(?![0-9A-Fa-f]{2})", value):
+        return False
     if any(character.isspace() for character in unquote(value)):
         return False
     try:
@@ -279,15 +288,15 @@ def looks_like_plist(raw: bytes) -> bool:
     prefix = raw.lstrip()
     if prefix.startswith(PLIST_BINARY_HEADER):
         return True
-    lowered_prefix = prefix[:256].lower()
-    lowered = raw.lower()
-    if lowered_prefix.startswith((PLIST_XML_MARKER, PLIST_DOCTYPE_MARKER)) or (
-        lowered_prefix.startswith(b"<?xml")
-        and (
-            PLIST_XML_MARKER in lowered
-            or PLIST_DOCTYPE_MARKER in lowered
-            or PLIST_PROPERTY_MARKER in lowered
-        )
+    prefix_window = prefix[:1024]
+    if PLIST_XML_PATTERN.match(prefix_window) or PLIST_DOCTYPE_PATTERN.match(
+        prefix_window
+    ):
+        return True
+    if prefix_window.lower().startswith(b"<?xml") and (
+        PLIST_XML_PATTERN.search(prefix_window)
+        or PLIST_DOCTYPE_PATTERN.search(prefix_window)
+        or PLIST_PROPERTY_DTD_PATTERN.search(prefix_window)
     ):
         return True
     # Executables and other binaries can embed plist-shaped string tables.
@@ -298,10 +307,10 @@ def looks_like_plist(raw: bytes) -> bool:
         raw.decode("utf-8")
     except UnicodeDecodeError:
         return False
-    return (
-        PLIST_XML_MARKER in lowered
-        or PLIST_DOCTYPE_MARKER in lowered
-        or PLIST_PROPERTY_MARKER in lowered
+    return bool(
+        PLIST_XML_PATTERN.search(raw)
+        or PLIST_DOCTYPE_PATTERN.search(raw)
+        or PLIST_PROPERTY_DTD_PATTERN.search(raw)
     )
 
 
@@ -320,23 +329,6 @@ def scan_file(path: Path, display: str, findings: list[tuple[str, str]], artifac
     scan_bytes(path, display, raw, findings)
 
 
-def safe_path_component(component: str) -> str:
-    if scan_line(component):
-        digest = hashlib.sha256(os.fsencode(component)).hexdigest()[:12]
-        return f"redacted-{digest}"
-    return component
-
-
-def safe_relative_path(root: Path, path: Path) -> str:
-    try:
-        relative = path.relative_to(root)
-    except ValueError:
-        return "outside-root"
-    if not relative.parts:
-        return "."
-    return "/".join(safe_path_component(part) for part in relative.parts)
-
-
 def scan_artifact(
     path: Path,
     findings: list[tuple[str, str]],
@@ -350,7 +342,7 @@ def scan_artifact(
         return
 
     if stat.S_ISREG(root_mode):
-        scan_file(path, label, findings, artifact=True)
+        scan_file(path, f"{label}:file-1", findings, artifact=True)
         return
     if not stat.S_ISDIR(root_mode) or stat.S_ISLNK(root_mode):
         report(findings, f"{label}:unreadable-root")
@@ -359,8 +351,21 @@ def scan_artifact(
     if walker is None:
         walker = os.walk
 
+    directory_labels: dict[Path, str] = {path: f"{label}:dir-1"}
+    next_directory_number = 2
+    next_file_number = 1
+
+    def directory_label(directory: Path) -> str:
+        nonlocal next_directory_number
+        if directory not in directory_labels:
+            directory_labels[directory] = f"{label}:dir-{next_directory_number}"
+            next_directory_number += 1
+        return directory_labels[directory]
+
+    current_directory_label = directory_label(path)
+
     def traversal_error(_error: OSError) -> None:
-        report(findings, f"{label}:unreadable")
+        report(findings, f"{current_directory_label}:unreadable")
 
     try:
         for directory, directories, filenames in walker(
@@ -370,27 +375,32 @@ def scan_artifact(
             followlinks=False,
         ):
             directory_path = Path(directory)
+            current_directory_label = directory_label(directory_path)
+            directories.sort()
+            filenames.sort()
             for name in list(directories):
                 child = directory_path / name
+                child_directory_label = directory_label(child)
                 try:
                     child_mode = child.lstat().st_mode
                 except OSError:
                     directories.remove(name)
                     report(
                         findings,
-                        f"{label}:{safe_relative_path(path, child)}:unreadable",
+                        f"{child_directory_label}:unreadable",
                     )
                     continue
                 if stat.S_ISLNK(child_mode):
                     directories.remove(name)
                     report(
                         findings,
-                        f"{label}:{safe_relative_path(path, child)}:symlink",
+                        f"{child_directory_label}:symlink",
                     )
 
             for name in filenames:
                 child = directory_path / name
-                display = f"{label}:{safe_relative_path(path, child)}"
+                display = f"{label}:file-{next_file_number}"
+                next_file_number += 1
                 try:
                     child_mode = child.lstat().st_mode
                 except OSError:
@@ -401,7 +411,7 @@ def scan_artifact(
                     continue
                 scan_file(child, display, findings, artifact=True)
     except OSError:
-        report(findings, f"{label}:unreadable")
+        report(findings, f"{current_directory_label}:unreadable")
 
 
 def main() -> int:
@@ -419,8 +429,8 @@ def main() -> int:
         report(findings, "tracked:git-files")
         files = []
 
-    for path in files:
-        scan_file(path, safe_relative_path(root, path), findings, artifact=False)
+    for index, path in enumerate(files, start=1):
+        scan_file(path, f"tracked-file-{index}", findings, artifact=False)
     for index, path in enumerate(args.extra_file, start=1):
         scan_file(path, f"extra-file-{index}", findings, artifact=False)
     for index, path in enumerate(args.artifact, start=1):

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Credential-safe scanner for tracked sources and built app artifacts.
+
+Findings intentionally contain only a path and line/key location.
+"""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+TEXT_SUFFIXES = {
+    ".entitlements",
+    ".js",
+    ".json",
+    ".md",
+    ".pbxproj",
+    ".plist",
+    ".scpt",
+    ".sh",
+    ".storyboard",
+    ".strings",
+    ".swift",
+    ".tsv",
+    ".xcconfig",
+    ".xib",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+
+REUSABLE_SECRET = re.compile(
+    r"""(?ix)
+    (?<![a-z0-9_])
+    (?:api[_-]?(?:key|secret)|access[_-]?token|authorization|bearer|
+       client[_-]?secret|credential|password|private[_-]?key|token)
+    \s*(?:=|:)\s*
+    (?:["']\s*)?
+    [a-z0-9_./+=:-]{8,}
+    """
+)
+URL = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
+CREDENTIAL_QUERY = re.compile(
+    r"(?i)(?:^|[?&#])(?:api[_-]?(?:key|secret)|access[_-]?token|client[_-]?secret|credential|password|token|secret)="
+)
+
+
+def report(findings: list[tuple[str, str]], location: str) -> None:
+    findings.append((location, ""))
+
+
+def scan_text(path: Path, display: str, findings: list[tuple[str, str]], excluded: set[Path]) -> None:
+    resolved = path.resolve()
+    if resolved in excluded or not path.is_file() or path.suffix.lower() not in TEXT_SUFFIXES:
+        return
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        report(findings, f"{display}:unreadable")
+        return
+    if b"\x00" in raw:
+        return
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if REUSABLE_SECRET.search(line):
+            report(findings, f"{display}:{line_number}")
+            continue
+        for match in URL.finditer(line):
+            candidate = match.group(0).rstrip(".,;)]}")
+            try:
+                parsed = urlsplit(candidate)
+            except ValueError:
+                report(findings, f"{display}:{line_number}")
+                break
+            if parsed.username is not None or parsed.password is not None:
+                report(findings, f"{display}:{line_number}")
+                break
+            if CREDENTIAL_QUERY.search(parsed.query) or CREDENTIAL_QUERY.search(parsed.fragment):
+                report(findings, f"{display}:{line_number}")
+                break
+
+
+def tracked_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    paths = [Path(item) for item in result.stdout.decode("utf-8").split("\x00") if item]
+    # Test fixtures intentionally exercise rejected URL shapes; production/config/build
+    # scanning remains strict, while the synthetic-file test covers scanner failure.
+    return [root / item for item in paths if not any(part.endswith("Tests") for part in item.parts)]
+
+
+def safe_endpoint(value: object) -> bool:
+    if not isinstance(value, str) or not value or value != value.strip():
+        return False
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "https"
+        and bool(parsed.hostname)
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.query == ""
+        and parsed.fragment == ""
+    )
+
+
+def scan_artifact(path: Path, findings: list[tuple[str, str]], excluded: set[Path]) -> None:
+    if not path.exists():
+        report(findings, f"{path}:missing")
+        return
+    candidates = [path] if path.is_file() else [item for item in path.rglob("*") if item.is_file()]
+    for item in candidates:
+        display = str(item)
+        if item.name == "Info.plist":
+            try:
+                with item.open("rb") as handle:
+                    plist = plistlib.load(handle)
+            except (OSError, plistlib.InvalidFileException, ValueError, TypeError):
+                report(findings, f"{display}:invalid-plist")
+                continue
+            value = plist.get("CurrencyInfoFeed") if isinstance(plist, dict) else None
+            if value not in (None, "") and not safe_endpoint(value):
+                report(findings, f"{display}:CurrencyInfoFeed")
+        scan_text(item, display, findings, excluded)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--artifact", action="append", default=[], type=Path)
+    parser.add_argument("--extra-file", action="append", default=[], type=Path)
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    findings: list[tuple[str, str]] = []
+    excluded = {Path(__file__).resolve()}
+    try:
+        files = tracked_files(root)
+    except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
+        report(findings, f"{root}:git-files")
+        files = []
+
+    for path in files:
+        scan_text(path, str(path.relative_to(root)), findings, excluded)
+    for path in args.extra_file:
+        scan_text(path, str(path), findings, excluded)
+    for path in args.artifact:
+        scan_artifact(path, findings, excluded)
+
+    for location, _ in sorted(set(findings)):
+        print(location)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -7,16 +7,22 @@ Findings intentionally contain only a path and a line/byte location.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import plistlib
 import re
+import stat
 import subprocess
 import sys
 from pathlib import Path
-from urllib.parse import parse_qsl, unquote_plus, urlsplit
+from urllib.parse import parse_qsl, unquote, unquote_plus, urlsplit
 
 
 PLIST_SUFFIXES = {".plist"}
+PLIST_BINARY_HEADER = b"bplist" + b"00"
+PLIST_XML_MARKER = b"<" + b"plist"
+PLIST_DOCTYPE_MARKER = b"<!" + b"doctype " + b"plist"
+PLIST_PROPERTY_MARKER = b"property" + b"list-1.0.dtd"
 SENSITIVE_NAMES = frozenset(
     {
         "apikey",
@@ -51,13 +57,13 @@ SENSITIVE_NAMES = frozenset(
 URL_PATTERN = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
 ASSIGNMENT_PATTERN = re.compile(
     r"""
-    (?<![A-Za-z0-9])
+    (?<![A-Za-z0-9_])
     (?P<name>
         \"(?:[^\"\\]|\\.)*\"
         |'(?:[^'\\]|\\.)*'
-        |[A-Za-z%][^\s=:,{}\[\]]{0,80}
+        |[A-Za-z%][A-Za-z0-9_.%\-]{0,80}
     )
-    [ \t]*(?:=|:)[ \t]*(?P<value>[^\r\n]*)
+    [ \t]*(?:=(?!=)|:(?!=))[ \t]*(?P<value>[^\r\n]*)
     """,
     re.VERBOSE,
 )
@@ -88,8 +94,7 @@ def is_sensitive_name(value: object) -> bool:
 def printable_value(value: str) -> bool:
     value = value.strip()
     return (
-        len(value) >= 8
-        and bool(value)
+        bool(value)
         and any(not character.isspace() for character in value)
         and all(character.isprintable() for character in value)
     )
@@ -209,6 +214,8 @@ def safe_endpoint(value: object) -> bool:
         return False
     if any(character.isspace() for character in value) or "$(" in value:
         return False
+    if any(character.isspace() for character in unquote(value)):
+        return False
     try:
         parsed = urlsplit(value)
         parsed.port
@@ -224,6 +231,8 @@ def safe_endpoint(value: object) -> bool:
         and bool(parsed.hostname)
         and parsed.username is None
         and parsed.password is None
+        and "?" not in value
+        and "#" not in value
         and parsed.query == ""
         and parsed.fragment == ""
     )
@@ -267,8 +276,14 @@ def scan_plist(raw: bytes, display: str, findings: list[tuple[str, str]], artifa
 
 
 def looks_like_plist(raw: bytes) -> bool:
-    prefix = raw.lstrip()[:4096]
-    return prefix.startswith(b"bplist00") or b"<plist" in prefix
+    prefix = raw.lstrip()
+    lowered = raw.lower()
+    return (
+        prefix.startswith(PLIST_BINARY_HEADER)
+        or PLIST_XML_MARKER in lowered
+        or PLIST_DOCTYPE_MARKER in lowered
+        or PLIST_PROPERTY_MARKER in lowered
+    )
 
 
 def scan_file(path: Path, display: str, findings: list[tuple[str, str]], artifact: bool) -> None:
@@ -286,13 +301,88 @@ def scan_file(path: Path, display: str, findings: list[tuple[str, str]], artifac
     scan_bytes(path, display, raw, findings)
 
 
-def scan_artifact(path: Path, findings: list[tuple[str, str]]) -> None:
-    if not path.exists():
-        report(findings, f"{path}:missing")
+def safe_path_component(component: str) -> str:
+    if scan_line(component):
+        digest = hashlib.sha256(os.fsencode(component)).hexdigest()[:12]
+        return f"redacted-{digest}"
+    return component
+
+
+def safe_relative_path(root: Path, path: Path) -> str:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return "outside-root"
+    if not relative.parts:
+        return "."
+    return "/".join(safe_path_component(part) for part in relative.parts)
+
+
+def scan_artifact(
+    path: Path,
+    findings: list[tuple[str, str]],
+    label: str = "artifact-1",
+    walker=None,
+) -> None:
+    try:
+        root_mode = path.lstat().st_mode
+    except OSError:
+        report(findings, f"{label}:missing")
         return
-    candidates = [path] if path.is_file() else [item for item in path.rglob("*") if item.is_file()]
-    for item in candidates:
-        scan_file(item, str(item), findings, artifact=True)
+
+    if stat.S_ISREG(root_mode):
+        scan_file(path, label, findings, artifact=True)
+        return
+    if not stat.S_ISDIR(root_mode) or stat.S_ISLNK(root_mode):
+        report(findings, f"{label}:unreadable-root")
+        return
+
+    if walker is None:
+        walker = os.walk
+
+    def traversal_error(_error: OSError) -> None:
+        report(findings, f"{label}:unreadable")
+
+    try:
+        for directory, directories, filenames in walker(
+            path,
+            topdown=True,
+            onerror=traversal_error,
+            followlinks=False,
+        ):
+            directory_path = Path(directory)
+            for name in list(directories):
+                child = directory_path / name
+                try:
+                    child_mode = child.lstat().st_mode
+                except OSError:
+                    directories.remove(name)
+                    report(
+                        findings,
+                        f"{label}:{safe_relative_path(path, child)}:unreadable",
+                    )
+                    continue
+                if stat.S_ISLNK(child_mode):
+                    directories.remove(name)
+                    report(
+                        findings,
+                        f"{label}:{safe_relative_path(path, child)}:symlink",
+                    )
+
+            for name in filenames:
+                child = directory_path / name
+                display = f"{label}:{safe_relative_path(path, child)}"
+                try:
+                    child_mode = child.lstat().st_mode
+                except OSError:
+                    report(findings, f"{display}:unreadable")
+                    continue
+                if stat.S_ISLNK(child_mode):
+                    report(findings, f"{display}:symlink")
+                    continue
+                scan_file(child, display, findings, artifact=True)
+    except OSError:
+        report(findings, f"{label}:unreadable")
 
 
 def main() -> int:
@@ -307,15 +397,15 @@ def main() -> int:
     try:
         files = tracked_files(root)
     except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
-        report(findings, f"{root}:git-files")
+        report(findings, "tracked:git-files")
         files = []
 
     for path in files:
-        scan_file(path, str(path.relative_to(root)), findings, artifact=False)
-    for path in args.extra_file:
-        scan_file(path, str(path), findings, artifact=False)
-    for path in args.artifact:
-        scan_artifact(path, findings)
+        scan_file(path, safe_relative_path(root, path), findings, artifact=False)
+    for index, path in enumerate(args.extra_file, start=1):
+        scan_file(path, f"extra-file-{index}", findings, artifact=False)
+    for index, path in enumerate(args.artifact, start=1):
+        scan_artifact(path, findings, label=f"artifact-{index}")
 
     for location, _ in sorted(set(findings)):
         print(location)

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -39,7 +39,7 @@ PLIST_SUFFIXES = {".entitlements", ".plist"}
 REUSABLE_SECRET = re.compile(
     r"""(?ix)
     (?<![a-z0-9_])
-    (?:api[_-]?(?:key|secret)|access[_-]?token|authorization|bearer|
+    (?:api[_-]?(?:key|secret)|access(?:[_-]?(?:token|key|secret))|authorization|bearer|
        client[_-]?secret|credential|password|private[_-]?key|token)
     \s*(?:=|:)\s*
     (?:["']\s*)?
@@ -47,11 +47,15 @@ REUSABLE_SECRET = re.compile(
     """
 )
 URL = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
-CREDENTIAL_QUERY = re.compile(
-    r"(?i)(?:^|[?&#])(?:api[_-]?(?:key|secret)|access[_-]?token|client[_-]?secret|credential|password|token|secret)="
+SENSITIVE_CREDENTIAL_KEY = re.compile(
+    r"""(?ix)
+    ^(?:api[_-]?(?:key|secret)
+      |access(?:[_-]?(?:token|key|secret))
+      |authorization|bearer|client[_-]?secret|credential|password|private[_-]?key|token|secret)$
+    """
 )
 SUSPICIOUS_PLIST_KEY = re.compile(
-    r"^(?:apikey|apisecret|accesstoken|authorization|bearer|clientsecret|credentials?|passwords?|privatekey|tokens?|secrets?)$"
+    r"^(?:accesskey|accesssecret|accesstoken|apikey|apisecret|authorization|bearer|clientsecret|credentials?|passwords?|privatekey|tokens?|secrets?)$"
 )
 
 
@@ -89,7 +93,7 @@ def scan_text(path: Path, display: str, findings: list[tuple[str, str]], exclude
             if parsed.username is not None or parsed.password is not None:
                 report(findings, f"{display}:{line_number}")
                 break
-            if CREDENTIAL_QUERY.search(parsed.query) or CREDENTIAL_QUERY.search(parsed.fragment):
+            if _has_credential_param(parsed.query) or _has_credential_param(parsed.fragment):
                 report(findings, f"{display}:{line_number}")
                 break
 
@@ -112,6 +116,12 @@ def safe_endpoint(value: object) -> bool:
         return False
     try:
         parsed = urlsplit(value)
+        parsed.port
+    except ValueError:
+        return False
+    try:
+        if parsed.port is not None and not (0 < parsed.port <= 65535):
+            return False
     except ValueError:
         return False
     return (
@@ -122,6 +132,13 @@ def safe_endpoint(value: object) -> bool:
         and parsed.query == ""
         and parsed.fragment == ""
     )
+
+
+def _has_credential_param(raw: str) -> bool:
+    for name, value in re.findall(r"([^&#=]+)=([^&#]*)", raw):
+        if SENSITIVE_CREDENTIAL_KEY.fullmatch(name) and value.strip():
+            return True
+    return False
 
 
 def is_nonempty_scalar(value: object) -> bool:

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -34,6 +34,7 @@ TEXT_SUFFIXES = {
     ".yaml",
     ".yml",
 }
+PLIST_SUFFIXES = {".entitlements", ".plist"}
 
 REUSABLE_SECRET = re.compile(
     r"""(?ix)
@@ -48,6 +49,9 @@ REUSABLE_SECRET = re.compile(
 URL = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
 CREDENTIAL_QUERY = re.compile(
     r"(?i)(?:^|[?&#])(?:api[_-]?(?:key|secret)|access[_-]?token|client[_-]?secret|credential|password|token|secret)="
+)
+SUSPICIOUS_PLIST_KEY = re.compile(
+    r"^(?:apikey|apisecret|accesstoken|authorization|bearer|clientsecret|credentials?|passwords?|privatekey|tokens?|secrets?)$"
 )
 
 
@@ -98,13 +102,13 @@ def tracked_files(root: Path) -> list[Path]:
         stderr=subprocess.DEVNULL,
     )
     paths = [Path(item) for item in result.stdout.decode("utf-8").split("\x00") if item]
-    # Test fixtures intentionally exercise rejected URL shapes; production/config/build
-    # scanning remains strict, while the synthetic-file test covers scanner failure.
-    return [root / item for item in paths if not any(part.endswith("Tests") for part in item.parts)]
+    return [root / item for item in paths]
 
 
 def safe_endpoint(value: object) -> bool:
     if not isinstance(value, str) or not value or value != value.strip():
+        return False
+    if any(character.isspace() for character in value) or "$(" in value:
         return False
     try:
         parsed = urlsplit(value)
@@ -120,6 +124,45 @@ def safe_endpoint(value: object) -> bool:
     )
 
 
+def is_nonempty_scalar(value: object) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (bytes, bytearray)):
+        return bool(value)
+    return not isinstance(value, (dict, list, tuple)) and value is not None
+
+
+def plist_key_name(key: object) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(key).lower())
+
+
+def scan_plist(path: Path, display: str, findings: list[tuple[str, str]], artifact: bool) -> None:
+    try:
+        with path.open("rb") as handle:
+            plist = plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException, ValueError, TypeError):
+        report(findings, f"{display}:invalid-plist")
+        return
+
+    def visit(value: object, key_path: str) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                child_path = f"{key_path}.{key}" if key_path else str(key)
+                normalized_key = plist_key_name(key)
+                if SUSPICIOUS_PLIST_KEY.fullmatch(normalized_key) and is_nonempty_scalar(child):
+                    report(findings, f"{display}:{child_path}")
+                if str(key) == "CurrencyInfoFeed" and child not in (None, ""):
+                    source_placeholder = not artifact and child == "$(CURRENCY_INFO_FEED)"
+                    if not source_placeholder and not safe_endpoint(child):
+                        report(findings, f"{display}:{child_path}")
+                visit(child, child_path)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                visit(child, f"{key_path}[{index}]")
+
+    visit(plist, "")
+
+
 def scan_artifact(path: Path, findings: list[tuple[str, str]], excluded: set[Path]) -> None:
     if not path.exists():
         report(findings, f"{path}:missing")
@@ -127,16 +170,8 @@ def scan_artifact(path: Path, findings: list[tuple[str, str]], excluded: set[Pat
     candidates = [path] if path.is_file() else [item for item in path.rglob("*") if item.is_file()]
     for item in candidates:
         display = str(item)
-        if item.name == "Info.plist":
-            try:
-                with item.open("rb") as handle:
-                    plist = plistlib.load(handle)
-            except (OSError, plistlib.InvalidFileException, ValueError, TypeError):
-                report(findings, f"{display}:invalid-plist")
-                continue
-            value = plist.get("CurrencyInfoFeed") if isinstance(plist, dict) else None
-            if value not in (None, "") and not safe_endpoint(value):
-                report(findings, f"{display}:CurrencyInfoFeed")
+        if item.suffix.lower() in PLIST_SUFFIXES:
+            scan_plist(item, display, findings, artifact=True)
         scan_text(item, display, findings, excluded)
 
 
@@ -157,9 +192,15 @@ def main() -> int:
         files = []
 
     for path in files:
-        scan_text(path, str(path.relative_to(root)), findings, excluded)
+        display = str(path.relative_to(root))
+        if path.suffix.lower() in PLIST_SUFFIXES:
+            scan_plist(path, display, findings, artifact=False)
+        scan_text(path, display, findings, excluded)
     for path in args.extra_file:
-        scan_text(path, str(path), findings, excluded)
+        display = str(path)
+        if path.suffix.lower() in PLIST_SUFFIXES:
+            scan_plist(path, display, findings, artifact=False)
+        scan_text(path, display, findings, excluded)
     for path in args.artifact:
         scan_artifact(path, findings, excluded)
 

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -1,101 +1,196 @@
 #!/usr/bin/env python3
 """Credential-safe scanner for tracked sources and built app artifacts.
 
-Findings intentionally contain only a path and line/key location.
+Findings intentionally contain only a path and a line/byte location.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import plistlib
 import re
 import subprocess
 import sys
 from pathlib import Path
-from urllib.parse import urlsplit
+from urllib.parse import parse_qsl, unquote_plus, urlsplit
 
 
-TEXT_SUFFIXES = {
-    ".entitlements",
-    ".js",
-    ".json",
-    ".md",
-    ".pbxproj",
-    ".plist",
-    ".scpt",
-    ".sh",
-    ".storyboard",
-    ".strings",
-    ".swift",
-    ".tsv",
-    ".xcconfig",
-    ".xib",
-    ".xml",
-    ".yaml",
-    ".yml",
-}
-PLIST_SUFFIXES = {".entitlements", ".plist"}
-
-REUSABLE_SECRET = re.compile(
-    r"""(?ix)
-    (?<![a-z0-9_])
-    (?:api[_-]?(?:key|secret)|access(?:[_-]?(?:token|key|secret))|authorization|bearer|
-       client[_-]?secret|credential|password|private[_-]?key|token)
-    \s*(?:=|:)\s*
-    (?:["']\s*)?
-    [a-z0-9_./+=:-]{8,}
-    """
+PLIST_SUFFIXES = {".plist"}
+SENSITIVE_NAMES = frozenset(
+    {
+        "apikey",
+        "apisecret",
+        "apitoken",
+        "accesskey",
+        "accesssecret",
+        "accesstoken",
+        "authkey",
+        "authsecret",
+        "authtoken",
+        "authorization",
+        "bearer",
+        "clientkey",
+        "clientsecret",
+        "clienttoken",
+        "clientcredential",
+        "clientcredentials",
+        "credential",
+        "credentials",
+        "password",
+        "passwords",
+        "privatekey",
+        "secretkey",
+        "token",
+        "tokens",
+        "secret",
+        "secrets",
+    }
 )
-URL = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
-SENSITIVE_CREDENTIAL_KEY = re.compile(
-    r"""(?ix)
-    ^(?:api[_-]?(?:key|secret)
-      |access(?:[_-]?(?:token|key|secret))
-      |authorization|bearer|client[_-]?secret|credential|password|private[_-]?key|token|secret)$
-    """
-)
-SUSPICIOUS_PLIST_KEY = re.compile(
-    r"^(?:accesskey|accesssecret|accesstoken|apikey|apisecret|authorization|bearer|clientsecret|credentials?|passwords?|privatekey|tokens?|secrets?)$"
+
+URL_PATTERN = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
+ASSIGNMENT_PATTERN = re.compile(
+    r"""
+    (?<![A-Za-z0-9])
+    (?P<name>
+        \"(?:[^\"\\]|\\.)*\"
+        |'(?:[^'\\]|\\.)*'
+        |[A-Za-z%][^\s=:,{}\[\]]{0,80}
+    )
+    [ \t]*(?:=|:)[ \t]*(?P<value>[^\r\n]*)
+    """,
+    re.VERBOSE,
 )
 
 
 def report(findings: list[tuple[str, str]], location: str) -> None:
-    findings.append((location, ""))
+    findings.append((location, "credential-like material"))
 
 
-def scan_text(path: Path, display: str, findings: list[tuple[str, str]], excluded: set[Path]) -> None:
-    resolved = path.resolve()
-    if resolved in excluded or not path.is_file() or path.suffix.lower() not in TEXT_SUFFIXES:
-        return
+def decode_name(value: object) -> str:
+    decoded = str(value)
+    for _ in range(3):
+        next_value = unquote_plus(decoded)
+        if next_value == decoded:
+            break
+        decoded = next_value
+    return decoded
+
+
+def normalized_name(value: object) -> str:
+    return re.sub(r"[^a-z0-9]", "", decode_name(value).lower())
+
+
+def is_sensitive_name(value: object) -> bool:
+    return normalized_name(value) in SENSITIVE_NAMES
+
+
+def printable_value(value: str) -> bool:
+    value = value.strip()
+    return (
+        len(value) >= 8
+        and bool(value)
+        and any(not character.isspace() for character in value)
+        and all(character.isprintable() for character in value)
+    )
+
+
+def assignment_value(raw: str) -> str:
+    candidate = raw.strip().rstrip(",;")
+    if len(candidate) >= 2 and candidate[0] in {"\"", "'"}:
+        quote = candidate[0]
+        escaped = False
+        for index in range(1, len(candidate)):
+            character = candidate[index]
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                return candidate[1:index]
+    return candidate
+
+
+def has_sensitive_assignment(line: str) -> bool:
+    for match in ASSIGNMENT_PATTERN.finditer(line):
+        if is_sensitive_name(match.group("name")) and printable_value(
+            assignment_value(match.group("value"))
+        ):
+            return True
+    return False
+
+
+def has_credential_param(raw: str) -> bool:
     try:
-        raw = path.read_bytes()
-    except OSError:
-        report(findings, f"{display}:unreadable")
-        return
-    if b"\x00" in raw:
-        return
+        pairs = parse_qsl(raw, keep_blank_values=True, strict_parsing=False)
+    except ValueError:
+        return False
+    return any(is_sensitive_name(name) and bool(value.strip()) for name, value in pairs)
+
+
+def scan_line(line: str) -> bool:
+    if has_sensitive_assignment(line):
+        return True
+    for match in URL_PATTERN.finditer(line):
+        candidate = match.group(0).rstrip(".,;!?)]}")
+        try:
+            parsed = urlsplit(candidate)
+        except ValueError:
+            return True
+        if (
+            parsed.username is not None
+            or parsed.password is not None
+            or has_credential_param(parsed.query)
+            or has_credential_param(parsed.fragment)
+        ):
+            return True
+    return False
+
+
+def scan_content(content: str) -> bool:
+    return any(scan_line(line) for line in content.splitlines())
+
+
+def printable_segments(raw: bytes) -> list[tuple[int, str]]:
+    segments: list[tuple[int, str]] = []
+    start: int | None = None
+    buffer: list[str] = []
+
+    def finish() -> None:
+        nonlocal start, buffer
+        if start is not None and buffer:
+            segments.append((start, "".join(buffer)))
+        start = None
+        buffer = []
+
+    for offset, byte in enumerate(raw):
+        character = chr(byte)
+        is_printable = byte in {9, 10, 13} or character.isprintable()
+        if is_printable:
+            if start is None:
+                start = offset
+            buffer.append(character)
+        else:
+            finish()
+    finish()
+    return segments
+
+
+def scan_bytes(path: Path, display: str, raw: bytes, findings: list[tuple[str, str]]) -> None:
     try:
         text = raw.decode("utf-8")
     except UnicodeDecodeError:
+        text = None
+
+    if text is not None and b"\x00" not in raw:
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if scan_line(line):
+                report(findings, f"{display}:{line_number}")
         return
 
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        if REUSABLE_SECRET.search(line):
-            report(findings, f"{display}:{line_number}")
-            continue
-        for match in URL.finditer(line):
-            candidate = match.group(0).rstrip(".,;)]}")
-            try:
-                parsed = urlsplit(candidate)
-            except ValueError:
-                report(findings, f"{display}:{line_number}")
-                break
-            if parsed.username is not None or parsed.password is not None:
-                report(findings, f"{display}:{line_number}")
-                break
-            if _has_credential_param(parsed.query) or _has_credential_param(parsed.fragment):
-                report(findings, f"{display}:{line_number}")
-                break
+    for offset, segment in printable_segments(raw):
+        if scan_content(segment):
+            report(findings, f"{display}:byte-{offset}")
 
 
 def tracked_files(root: Path) -> list[Path]:
@@ -105,7 +200,7 @@ def tracked_files(root: Path) -> list[Path]:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     )
-    paths = [Path(item) for item in result.stdout.decode("utf-8").split("\x00") if item]
+    paths = [Path(os.fsdecode(item)) for item in result.stdout.split(b"\0") if item]
     return [root / item for item in paths]
 
 
@@ -134,30 +229,22 @@ def safe_endpoint(value: object) -> bool:
     )
 
 
-def _has_credential_param(raw: str) -> bool:
-    for name, value in re.findall(r"([^&#=]+)=([^&#]*)", raw):
-        if SENSITIVE_CREDENTIAL_KEY.fullmatch(name) and value.strip():
-            return True
-    return False
-
-
-def is_nonempty_scalar(value: object) -> bool:
+def is_credential_material(value: object) -> bool:
     if isinstance(value, str):
         return bool(value.strip())
     if isinstance(value, (bytes, bytearray)):
         return bool(value)
-    return not isinstance(value, (dict, list, tuple)) and value is not None
+    return False
 
 
 def plist_key_name(key: object) -> str:
-    return re.sub(r"[^a-z0-9]", "", str(key).lower())
+    return normalized_name(key)
 
 
-def scan_plist(path: Path, display: str, findings: list[tuple[str, str]], artifact: bool) -> None:
+def scan_plist(raw: bytes, display: str, findings: list[tuple[str, str]], artifact: bool) -> None:
     try:
-        with path.open("rb") as handle:
-            plist = plistlib.load(handle)
-    except (OSError, plistlib.InvalidFileException, ValueError, TypeError):
+        plist = plistlib.loads(raw)
+    except Exception:
         report(findings, f"{display}:invalid-plist")
         return
 
@@ -165,8 +252,7 @@ def scan_plist(path: Path, display: str, findings: list[tuple[str, str]], artifa
         if isinstance(value, dict):
             for key, child in value.items():
                 child_path = f"{key_path}.{key}" if key_path else str(key)
-                normalized_key = plist_key_name(key)
-                if SUSPICIOUS_PLIST_KEY.fullmatch(normalized_key) and is_nonempty_scalar(child):
+                if is_sensitive_name(key) and is_credential_material(child):
                     report(findings, f"{display}:{child_path}")
                 if str(key) == "CurrencyInfoFeed" and child not in (None, ""):
                     source_placeholder = not artifact and child == "$(CURRENCY_INFO_FEED)"
@@ -180,28 +266,44 @@ def scan_plist(path: Path, display: str, findings: list[tuple[str, str]], artifa
     visit(plist, "")
 
 
-def scan_artifact(path: Path, findings: list[tuple[str, str]], excluded: set[Path]) -> None:
+def looks_like_plist(raw: bytes) -> bool:
+    prefix = raw.lstrip()[:4096]
+    return prefix.startswith(b"bplist00") or b"<plist" in prefix
+
+
+def scan_file(path: Path, display: str, findings: list[tuple[str, str]], artifact: bool) -> None:
+    if not path.is_file():
+        report(findings, f"{display}:unreadable")
+        return
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        report(findings, f"{display}:unreadable")
+        return
+
+    if path.suffix.lower() in PLIST_SUFFIXES or looks_like_plist(raw):
+        scan_plist(raw, display, findings, artifact=artifact)
+    scan_bytes(path, display, raw, findings)
+
+
+def scan_artifact(path: Path, findings: list[tuple[str, str]]) -> None:
     if not path.exists():
         report(findings, f"{path}:missing")
         return
     candidates = [path] if path.is_file() else [item for item in path.rglob("*") if item.is_file()]
     for item in candidates:
-        display = str(item)
-        if item.suffix.lower() in PLIST_SUFFIXES:
-            scan_plist(item, display, findings, artifact=True)
-        scan_text(item, display, findings, excluded)
+        scan_file(item, str(item), findings, artifact=True)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument("--root", type=Path, required=True)
-    parser.add_argument("--artifact", action="append", default=[], type=Path)
     parser.add_argument("--extra-file", action="append", default=[], type=Path)
+    parser.add_argument("--artifact", action="append", default=[], type=Path)
     args = parser.parse_args()
 
     root = args.root.resolve()
     findings: list[tuple[str, str]] = []
-    excluded = {Path(__file__).resolve()}
     try:
         files = tracked_files(root)
     except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
@@ -209,17 +311,11 @@ def main() -> int:
         files = []
 
     for path in files:
-        display = str(path.relative_to(root))
-        if path.suffix.lower() in PLIST_SUFFIXES:
-            scan_plist(path, display, findings, artifact=False)
-        scan_text(path, display, findings, excluded)
+        scan_file(path, str(path.relative_to(root)), findings, artifact=False)
     for path in args.extra_file:
-        display = str(path)
-        if path.suffix.lower() in PLIST_SUFFIXES:
-            scan_plist(path, display, findings, artifact=False)
-        scan_text(path, display, findings, excluded)
+        scan_file(path, str(path), findings, artifact=False)
     for path in args.artifact:
-        scan_artifact(path, findings, excluded)
+        scan_artifact(path, findings)
 
     for location, _ in sorted(set(findings)):
         print(location)

--- a/Scripts/scan-credential-safety.py
+++ b/Scripts/scan-credential-safety.py
@@ -277,10 +277,29 @@ def scan_plist(raw: bytes, display: str, findings: list[tuple[str, str]], artifa
 
 def looks_like_plist(raw: bytes) -> bool:
     prefix = raw.lstrip()
+    if prefix.startswith(PLIST_BINARY_HEADER):
+        return True
+    lowered_prefix = prefix[:256].lower()
     lowered = raw.lower()
+    if lowered_prefix.startswith((PLIST_XML_MARKER, PLIST_DOCTYPE_MARKER)) or (
+        lowered_prefix.startswith(b"<?xml")
+        and (
+            PLIST_XML_MARKER in lowered
+            or PLIST_DOCTYPE_MARKER in lowered
+            or PLIST_PROPERTY_MARKER in lowered
+        )
+    ):
+        return True
+    # Executables and other binaries can embed plist-shaped string tables.
+    # Scan their printable bytes, but do not parse the entire binary as a plist.
+    if b"\x00" in raw:
+        return False
+    try:
+        raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
     return (
-        prefix.startswith(PLIST_BINARY_HEADER)
-        or PLIST_XML_MARKER in lowered
+        PLIST_XML_MARKER in lowered
         or PLIST_DOCTYPE_MARKER in lowered
         or PLIST_PROPERTY_MARKER in lowered
     )

--- a/Scripts/test_scan_credential_safety.py
+++ b/Scripts/test_scan_credential_safety.py
@@ -11,6 +11,20 @@ SCANNER = runpy.run_path(str(Path(__file__).with_name("scan-credential-safety.py
 
 
 class ScannerTraversalTests(unittest.TestCase):
+    def test_sensitive_names_have_no_length_or_percent_nesting_bypass(self):
+        long_name = "api" + ("-" * 256) + "key"
+        self.assertTrue(SCANNER["has_sensitive_assignment"](long_name + "=x"))
+
+        encoded_name = "api" + "%5F" + "key"
+        for _ in range(8):
+            encoded_name = encoded_name.replace("%", "%25")
+        self.assertTrue(SCANNER["has_credential_param"](encoded_name + "=x"))
+
+    def test_empty_url_delimiters_are_not_trimmed(self):
+        endpoint = "https://" + "rates.example.invalid/feed"
+        self.assertTrue(SCANNER["scan_line"](endpoint + "?"))
+        self.assertTrue(SCANNER["scan_line"](endpoint + "#"))
+
     def test_injected_traversal_error_is_reported_with_opaque_label(self):
         with tempfile.TemporaryDirectory() as directory:
             findings = []

--- a/Scripts/test_scan_credential_safety.py
+++ b/Scripts/test_scan_credential_safety.py
@@ -1,4 +1,7 @@
+import contextlib
+import io
 import runpy
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -25,7 +28,53 @@ class ScannerTraversalTests(unittest.TestCase):
                 walker=failing_walker,
             )
 
-        self.assertEqual(findings, [("artifact-7:unreadable", "credential-like material")])
+        self.assertEqual(
+            findings,
+            [("artifact-7:dir-1:unreadable", "credential-like material")],
+        )
+
+    def test_tracked_and_nested_artifact_labels_do_not_include_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            tracked_file = root / ("tracked" + "-credential-name")
+            tracked_file.write_text("api" + "Key" + "=synthetic-value\n", encoding="utf-8")
+            artifact_root = root / ("artifact" + "-credential-name")
+            nested_directory = artifact_root / ("nested" + "-credential-name")
+            nested_directory.mkdir(parents=True)
+            artifact_file = nested_directory / ("artifact" + "-credential-name")
+            artifact_file.write_text("secret" + "Key" + "=synthetic-value\n", encoding="utf-8")
+            symlink = artifact_root / ("directory" + "-link")
+            symlink.symlink_to(nested_directory, target_is_directory=True)
+
+            scanner_globals = SCANNER["main"].__globals__
+            original_tracked_files = scanner_globals["tracked_files"]
+            original_argv = sys.argv
+            scanner_globals["tracked_files"] = lambda _root: [tracked_file]
+            sys.argv = ["scan-credential-safety.py", "--root", str(root)]
+            output = io.StringIO()
+            try:
+                with contextlib.redirect_stdout(output):
+                    status = SCANNER["main"]()
+            finally:
+                scanner_globals["tracked_files"] = original_tracked_files
+                sys.argv = original_argv
+
+            self.assertEqual(status, 1)
+            self.assertIn("tracked-file-1:1", output.getvalue())
+            self.assertNotIn(str(tracked_file), output.getvalue())
+
+            findings = []
+            SCANNER["scan_artifact"](artifact_root, findings, label="artifact-7")
+            locations = [location for location, _ in findings]
+            self.assertIn("artifact-7:file-1:1", locations)
+            self.assertTrue(
+                any(
+                    location.startswith("artifact-7:dir-")
+                    and location.endswith(":symlink")
+                    for location in locations
+                )
+            )
+            self.assertNotIn(str(artifact_root), str(findings))
 
 
 if __name__ == "__main__":

--- a/Scripts/test_scan_credential_safety.py
+++ b/Scripts/test_scan_credential_safety.py
@@ -1,0 +1,32 @@
+import runpy
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCANNER = runpy.run_path(str(Path(__file__).with_name("scan-credential-safety.py")))
+
+
+class ScannerTraversalTests(unittest.TestCase):
+    def test_injected_traversal_error_is_reported_with_opaque_label(self):
+        with tempfile.TemporaryDirectory() as directory:
+            findings = []
+
+            def failing_walker(_path, topdown, onerror, followlinks):
+                self.assertTrue(topdown)
+                self.assertFalse(followlinks)
+                onerror(OSError("injected traversal failure"))
+                return iter(())
+
+            SCANNER["scan_artifact"](
+                Path(directory),
+                findings,
+                label="artifact-7",
+                walker=failing_walker,
+            )
+
+        self.assertEqual(findings, [("artifact-7:unreadable", "credential-like material")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -16,7 +16,6 @@ struct CurrencyRateEntity : Decodable {
     var fetched_localtime : Date?
     var timestamp: Int
 }
-
 class CurrencyConverter {
     private let currencyRateEntityLock = NSLock()
     private var currencyRateEntityStorage: CurrencyRateEntity?
@@ -62,6 +61,7 @@ class CurrencyConverter {
     private let clock: () -> Date
     private let defaults: UserDefaults
     private let transport: RateTransport
+    private let feedConfiguration: CurrencyInfoFeedConfiguration.Resolution
     // When both are needed, defaultsLock is acquired before currencyRateEntityLock;
     // injected defaults callbacks never run while the entity lock is held.
     private let defaultsLock = NSRecursiveLock()
@@ -75,15 +75,17 @@ class CurrencyConverter {
     private init() {
         clock = Date.init
         defaults = sharedUserDefaults
+        feedConfiguration = CurrencyInfoFeedConfiguration.resolve(bundle: .main)
         transport = { url, completion in
             URLSession.shared.dataTask(with: url, completionHandler: completion).resume()
         }
     }
 
-    init(context: NSExtensionContext? = nil, clock: @escaping () -> Date = Date.init, defaults: UserDefaults = sharedUserDefaults, transport: RateTransport? = nil) {
+    init(context: NSExtensionContext? = nil, clock: @escaping () -> Date = Date.init, defaults: UserDefaults = sharedUserDefaults, feedConfiguration: CurrencyInfoFeedConfiguration.Resolution? = nil, transport: RateTransport? = nil) {
         self.context = context
         self.clock = clock
         self.defaults = defaults
+        self.feedConfiguration = feedConfiguration ?? CurrencyInfoFeedConfiguration.resolve(bundle: .main)
         self.transport = transport ?? { url, completion in
             URLSession.shared.dataTask(with: url, completionHandler: completion).resume()
         }
@@ -124,21 +126,20 @@ class CurrencyConverter {
     }
 
     private func loadFromWebRequest(_ completionHandler: @escaping (Error?) -> Void) {
-        let feed_url : URL?
-        if let feed_url_str = Bundle.main.object(forInfoDictionaryKey: "CurrencyInfoFeed") as? String {
-            feed_url = URL(string: feed_url_str)
-        } else {
-            feed_url = URL(string: "http://data.fixer.io/api/latest?access_key=676ac77e5ce5d4b9a57ee6464ff84433&format=1")
-        }
-
-        guard let feed_url else {
-            let error = RateDataError.unavailable
-            self.recordRefreshFailure(error)
-            completionHandler(error)
+        let feedURL: URL
+        switch feedConfiguration {
+        case .success(let url):
+            feedURL = url
+        case .failure(let configurationError):
+            let refreshError: RateDataError = configurationError == .missing
+                ? .unavailable
+                : .invalidConfiguration
+            self.recordRefreshFailure(refreshError)
+            completionHandler(refreshError)
             return
         }
 
-        transport(feed_url, { (data, response, error) in
+        transport(feedURL, { (data, response, error) in
             if error != nil {
                 let refreshError = RateDataError.transport
                 self.recordRefreshFailure(refreshError)

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -128,14 +128,8 @@ class CurrencyConverter {
     private func loadFromWebRequest(_ completionHandler: @escaping (Error?) -> Void) {
         let feedURL: URL
         switch feedConfiguration {
-        case .success(let url):
-            guard CurrencyInfoFeedConfiguration.validate(url: url) == nil else {
-                let refreshError = RateDataError.invalidConfiguration
-                self.recordRefreshFailure(refreshError)
-                completionHandler(refreshError)
-                return
-            }
-            feedURL = url
+        case .success(let endpoint):
+            feedURL = endpoint.url
         case .failure(let configurationError):
             let refreshError: RateDataError = configurationError == .missing
                 ? .unavailable

--- a/Shared/CurrencyConverter.swift
+++ b/Shared/CurrencyConverter.swift
@@ -129,6 +129,12 @@ class CurrencyConverter {
         let feedURL: URL
         switch feedConfiguration {
         case .success(let url):
+            guard CurrencyInfoFeedConfiguration.validate(url: url) == nil else {
+                let refreshError = RateDataError.invalidConfiguration
+                self.recordRefreshFailure(refreshError)
+                completionHandler(refreshError)
+                return
+            }
             feedURL = url
         case .failure(let configurationError):
             let refreshError: RateDataError = configurationError == .missing

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -9,8 +9,16 @@ enum CurrencyInfoFeedConfigurationError: Error, Equatable {
     case fragment
 }
 
+struct CurrencyInfoFeedEndpoint: Equatable {
+    let url: URL
+
+    fileprivate init(url: URL) {
+        self.url = url
+    }
+}
+
 enum CurrencyInfoFeedConfiguration {
-    typealias Resolution = Result<URL, CurrencyInfoFeedConfigurationError>
+    typealias Resolution = Result<CurrencyInfoFeedEndpoint, CurrencyInfoFeedConfigurationError>
     static let infoDictionaryKey = "CurrencyInfoFeed"
 
     static func resolve(value: Any?) -> Resolution {
@@ -22,22 +30,14 @@ enum CurrencyInfoFeedConfiguration {
         if let error = validate(url: url, rawValue: value) {
             return .failure(error)
         }
-        return .success(url)
-    }
-
-    static func validate(url: URL) -> CurrencyInfoFeedConfigurationError? {
-        validate(url: url, rawValue: url.absoluteString, rejectCanonicalizedPercent: true)
+        return .success(CurrencyInfoFeedEndpoint(url: url))
     }
 
     static func resolve(bundle: Bundle) -> Resolution {
         resolve(value: bundle.object(forInfoDictionaryKey: infoDictionaryKey))
     }
 
-    private static func validate(
-        url: URL,
-        rawValue: String,
-        rejectCanonicalizedPercent: Bool = false
-    ) -> CurrencyInfoFeedConfigurationError? {
+    private static func validate(url: URL, rawValue: String) -> CurrencyInfoFeedConfigurationError? {
         guard !rawValue.isEmpty,
               rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
               rawValue.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
@@ -45,12 +45,6 @@ enum CurrencyInfoFeedConfiguration {
             return .malformed
         }
         guard let decoded = rawValue.removingPercentEncoding else {
-            return .malformed
-        }
-        // Foundation canonicalizes malformed injected percent escapes to %25,
-        // so reject that canonicalized form during URL-only revalidation.
-        if rejectCanonicalizedPercent,
-           rawValue.range(of: "%25", options: [.caseInsensitive]) != nil {
             return .malformed
         }
         if decoded.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -26,22 +26,34 @@ enum CurrencyInfoFeedConfiguration {
     }
 
     static func validate(url: URL) -> CurrencyInfoFeedConfigurationError? {
-        validate(url: url, rawValue: url.absoluteString)
+        validate(url: url, rawValue: url.absoluteString, rejectCanonicalizedPercent: true)
     }
 
     static func resolve(bundle: Bundle) -> Resolution {
         resolve(value: bundle.object(forInfoDictionaryKey: infoDictionaryKey))
     }
 
-    private static func validate(url: URL, rawValue: String) -> CurrencyInfoFeedConfigurationError? {
+    private static func validate(
+        url: URL,
+        rawValue: String,
+        rejectCanonicalizedPercent: Bool = false
+    ) -> CurrencyInfoFeedConfigurationError? {
         guard !rawValue.isEmpty,
               rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
               rawValue.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return .malformed
         }
-        if let decoded = rawValue.removingPercentEncoding,
-           decoded.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {
+        guard let decoded = rawValue.removingPercentEncoding else {
+            return .malformed
+        }
+        // Foundation canonicalizes malformed injected percent escapes to %25,
+        // so reject that canonicalized form during URL-only revalidation.
+        if rejectCanonicalizedPercent,
+           rawValue.range(of: "%25", options: [.caseInsensitive]) != nil {
+            return .malformed
+        }
+        if decoded.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {
             return .malformed
         }
 

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -1,5 +1,62 @@
 import Foundation
 
+enum CurrencyInfoFeedConfigurationError: Error, Equatable {
+    case missing
+    case malformed
+    case nonHTTPS
+    case userinfo
+    case query
+    case fragment
+}
+
+enum CurrencyInfoFeedConfiguration {
+    typealias Resolution = Result<URL, CurrencyInfoFeedConfigurationError>
+    static let infoDictionaryKey = "CurrencyInfoFeed"
+
+    static func resolve(value: Any?) -> Resolution {
+        guard let value = value as? String else {
+            return .failure(value == nil ? .missing : .malformed)
+        }
+        guard !value.isEmpty else { return .failure(.missing) }
+        guard value == value.trimmingCharacters(in: .whitespacesAndNewlines),
+              value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              let url = URL(string: value),
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme?.lowercased() == "https",
+              let host = components.host,
+              !host.isEmpty else {
+            if let url = URL(string: value),
+               let scheme = URLComponents(url: url, resolvingAgainstBaseURL: false)?.scheme,
+               scheme.lowercased() != "https" {
+                return .failure(.nonHTTPS)
+            }
+            return .failure(.malformed)
+        }
+
+        if components.user != nil || components.password != nil || authority(in: value).contains("@") {
+            return .failure(.userinfo)
+        }
+        if value.contains("?") || components.query != nil {
+            return .failure(.query)
+        }
+        if value.contains("#") || components.fragment != nil {
+            return .failure(.fragment)
+        }
+        return .success(url)
+    }
+
+    static func resolve(bundle: Bundle) -> Resolution {
+        resolve(value: bundle.object(forInfoDictionaryKey: infoDictionaryKey))
+    }
+
+    private static func authority(in value: String) -> String {
+        guard let separator = value.range(of: "://") else { return "" }
+        let authorityStart = separator.upperBound
+        let remainder = value[authorityStart...]
+        return String(remainder.prefix { $0 != "/" && $0 != "?" && $0 != "#" })
+    }
+}
+
 enum RateDataSource: Equatable {
     case memory
     case defaults
@@ -11,6 +68,7 @@ enum RateDataError: Error, Equatable {
     case httpStatus(Int)
     case decode
     case invalidPayload
+    case invalidConfiguration
     case missingRate(String)
     case unavailable
 
@@ -24,6 +82,8 @@ enum RateDataError: Error, Equatable {
             return "Rate service returned unreadable data."
         case .invalidPayload:
             return "Rate service returned invalid data."
+        case .invalidConfiguration:
+            return "Rate feed configuration is invalid."
         case .missingRate:
             return "Requested currency rate unavailable."
         case .unavailable:

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -32,6 +32,9 @@ enum CurrencyInfoFeedConfiguration {
             }
             return .failure(.malformed)
         }
+        if let port = components.port, !(1...65535).contains(port) {
+            return .failure(.malformed)
+        }
 
         if components.user != nil || components.password != nil || authority(in: value).contains("@") {
             return .failure(.userinfo)

--- a/Shared/LegacyContractSeams.swift
+++ b/Shared/LegacyContractSeams.swift
@@ -18,38 +18,53 @@ enum CurrencyInfoFeedConfiguration {
             return .failure(value == nil ? .missing : .malformed)
         }
         guard !value.isEmpty else { return .failure(.missing) }
-        guard value == value.trimmingCharacters(in: .whitespacesAndNewlines),
-              value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
-              let url = URL(string: value),
-              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              components.scheme?.lowercased() == "https",
-              let host = components.host,
-              !host.isEmpty else {
-            if let url = URL(string: value),
-               let scheme = URLComponents(url: url, resolvingAgainstBaseURL: false)?.scheme,
-               scheme.lowercased() != "https" {
-                return .failure(.nonHTTPS)
-            }
-            return .failure(.malformed)
-        }
-        if let port = components.port, !(1...65535).contains(port) {
-            return .failure(.malformed)
-        }
-
-        if components.user != nil || components.password != nil || authority(in: value).contains("@") {
-            return .failure(.userinfo)
-        }
-        if value.contains("?") || components.query != nil {
-            return .failure(.query)
-        }
-        if value.contains("#") || components.fragment != nil {
-            return .failure(.fragment)
+        guard let url = URL(string: value) else { return .failure(.malformed) }
+        if let error = validate(url: url, rawValue: value) {
+            return .failure(error)
         }
         return .success(url)
     }
 
+    static func validate(url: URL) -> CurrencyInfoFeedConfigurationError? {
+        validate(url: url, rawValue: url.absoluteString)
+    }
+
     static func resolve(bundle: Bundle) -> Resolution {
         resolve(value: bundle.object(forInfoDictionaryKey: infoDictionaryKey))
+    }
+
+    private static func validate(url: URL, rawValue: String) -> CurrencyInfoFeedConfigurationError? {
+        guard !rawValue.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
+              rawValue.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return .malformed
+        }
+        if let decoded = rawValue.removingPercentEncoding,
+           decoded.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {
+            return .malformed
+        }
+
+        guard components.scheme?.lowercased() == "https" else {
+            if let scheme = components.scheme, scheme.lowercased() != "https" {
+                return .nonHTTPS
+            }
+            return .malformed
+        }
+        guard let host = components.host, !host.isEmpty else { return .malformed }
+        if let port = components.port, !(1...65535).contains(port) {
+            return .malformed
+        }
+        if components.user != nil || components.password != nil || authority(in: rawValue).contains("@") {
+            return .userinfo
+        }
+        if rawValue.contains("?") || components.query != nil {
+            return .query
+        }
+        if rawValue.contains("#") || components.fragment != nil {
+            return .fragment
+        }
+        return nil
     }
 
     private static func authority(in value: String) -> String {


### PR DESCRIPTION
## Summary
- Remove committed rate-feed credentials and credential-bearing fallback URLs.
- Wire a credential-free, HTTPS-only optional endpoint through app and extension xcconfig/plist configuration.
- Revalidate even directly injected URLs immediately before transport and fail closed with zero transport.
- Scan every tracked and artifact file, including unknown, extensionless, binary, invalid-UTF-8, and scanner source content, without echoing values or credential-bearing paths.
- Fail closed on unreadable traversal and structural plist errors while treating embedded plist-shaped executable strings as binary content.

## Verification
- HEAD: `1c2987c`
- Focused CCS-28: 29 tests, 0 failures
- Full suite: 82 tests, 0 failures
- CCS-10 + CCS-17 TSan: 29 tests, 0 failures, 0 warnings/races
- Default app + extension builds: PASS; processed feed empty; current artifact scans PASS
- Temporary credential-free injected app + extension builds: PASS; exact safe endpoint; current artifact scans PASS; private config removed
- Tracked scanner and Python traversal/path tests: PASS
- Project/plist/Core Data/XIB/diff: PASS
- GitGuardian Security Checks: SUCCESS

## Review
- Syntax-preserving value-redacted immutable patch SHA-256: `43897879c0caad837c1fa34d479868579351714d9b13a4a945dfa1be65388ca9`
- Patch structure: 77,938 bytes, 1,746 lines, 13 diff headers; `git apply --stat` and `--numstat` parse PASS.
- Fresh fail-closed review pending; do not merge until PASS.

## External closure blocker
Do not mark CCS-28 Fixed until owner evidence covers provider revoke/rotate, intermediary rotation/deployment when applicable, Git history assessment, GitHub release artifact actions, downstream fork/clone/cache acknowledgements, and owner sign-off. This PR does not claim external remediation is complete.



