### PR TITLE
CCS-22 make extension settings action truthful

### DIFF
--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -26,6 +26,10 @@
 		63CC34512531982E00466679 /* AtomicRenew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34502531982E00466679 /* AtomicRenew.swift */; };
 		63CC34522531982E00466679 /* AtomicRenew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34502531982E00466679 /* AtomicRenew.swift */; };
 		63CC34532531982E00466679 /* AtomicRenew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34502531982E00466679 /* AtomicRenew.swift */; };
+		63CC34612531982E00466679 /* SafariExtensionSettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34602531982E00466679 /* SafariExtensionSettingsState.swift */; };
+		63CC34622531982E00466679 /* SafariExtensionSettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34602531982E00466679 /* SafariExtensionSettingsState.swift */; };
+		63CC34632531982E00466679 /* SafariExtensionSettingsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34652531982E00466679 /* SafariExtensionSettingsAdapter.swift */; };
+		63CC34642531982E00466679 /* CCS22SafariExtensionSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34662531982E00466679 /* CCS22SafariExtensionSettingsTests.swift */; };
 		625712FC2371982E00466679 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625712FB2371982E00466679 /* Cocoa.framework */; };
 		625712FF2371982E00466679 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625712FE2371982E00466679 /* SafariExtensionHandler.swift */; };
 		625713012371982E00466679 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625713002371982E00466679 /* SafariExtensionViewController.swift */; };
@@ -114,6 +118,9 @@
 		63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS10RateFallbackTests.swift; sourceTree = "<group>"; };
 		63CC34402371982E00466679 /* CCS21AtomicRenewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS21AtomicRenewTests.swift; sourceTree = "<group>"; };
 		63CC34502531982E00466679 /* AtomicRenew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicRenew.swift; sourceTree = "<group>"; };
+		63CC34602531982E00466679 /* SafariExtensionSettingsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionSettingsState.swift; sourceTree = "<group>"; };
+		63CC34652531982E00466679 /* SafariExtensionSettingsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionSettingsAdapter.swift; sourceTree = "<group>"; };
+		63CC34662531982E00466679 /* CCS22SafariExtensionSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS22SafariExtensionSettingsTests.swift; sourceTree = "<group>"; };
 		625712E62371982E00466679 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		625712F62371982E00466679 /* CurrencyConverter Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CurrencyConverter Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		625712FB2371982E00466679 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -201,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				625712E42371982E00466679 /* CurrencyConverterTests.swift */,
+				63CC34662531982E00466679 /* CCS22SafariExtensionSettingsTests.swift */,
 				63CC34022371982E00466679 /* CCS34CharacterizationTests.swift */,
 				63CC34202371982E00466679 /* CCS17RefreshCoalescingTests.swift */,
 				63CC34302371982E00466679 /* CCS10RateFallbackTests.swift */,
@@ -238,6 +246,7 @@
 		6257131E23719B9800466679 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				63CC34602531982E00466679 /* SafariExtensionSettingsState.swift */,
 				63CC34502531982E00466679 /* AtomicRenew.swift */,
 				63CC34122531982E00466679 /* ConvertHistoryUIBeanProduction.swift */,
 				63CC34002371982E00466679 /* LegacyContractSeams.swift */,
@@ -257,6 +266,7 @@
 			children = (
 				6285039A251B936F00E381AA /* AppDelegate.swift */,
 				6285039C251B936F00E381AA /* ContentView.swift */,
+				63CC34652531982E00466679 /* SafariExtensionSettingsAdapter.swift */,
 				628503A1251B937100E381AA /* Assets.xcassets */,
 				628503A6251B937100E381AA /* Main.storyboard */,
 				628503A9251B937100E381AA /* Info.plist */,
@@ -421,6 +431,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63CC34642531982E00466679 /* CCS22SafariExtensionSettingsTests.swift in Sources */,
+				63CC34622531982E00466679 /* SafariExtensionSettingsState.swift in Sources */,
 				62B81E67254240C70015CC19 /* CreditCardProfile.swift in Sources */,
 				62B81E4A2542155D0015CC19 /* CurrencySymbolMap.swift in Sources */,
 				6257132323719BDC00466679 /* SharedPersistent.swift in Sources */,
@@ -464,6 +476,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63CC34632531982E00466679 /* SafariExtensionSettingsAdapter.swift in Sources */,
+				63CC34622531982E00466679 /* SafariExtensionSettingsState.swift in Sources */,
 				6262F06925220FA90066ADFA /* SharedPersistent.swift in Sources */,
 				6262F07F252226100066ADFA /* PreviewConvertHistory.swift in Sources */,
 				621C84462537492900DC7ECC /* ApiSyncInfoViewModel.swift in Sources */,

--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		63CC34622531982E00466679 /* SafariExtensionSettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34602531982E00466679 /* SafariExtensionSettingsState.swift */; };
 		63CC34632531982E00466679 /* SafariExtensionSettingsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34652531982E00466679 /* SafariExtensionSettingsAdapter.swift */; };
 		63CC34642531982E00466679 /* CCS22SafariExtensionSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34662531982E00466679 /* CCS22SafariExtensionSettingsTests.swift */; };
+		63CC34682531982E00466679 /* SafariExtensionSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34672531982E00466679 /* SafariExtensionSettingsViewModel.swift */; };
+		63CC34692531982E00466679 /* SafariExtensionSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC34672531982E00466679 /* SafariExtensionSettingsViewModel.swift */; };
 		625712FC2371982E00466679 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625712FB2371982E00466679 /* Cocoa.framework */; };
 		625712FF2371982E00466679 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625712FE2371982E00466679 /* SafariExtensionHandler.swift */; };
 		625713012371982E00466679 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625713002371982E00466679 /* SafariExtensionViewController.swift */; };
@@ -121,6 +123,7 @@
 		63CC34602531982E00466679 /* SafariExtensionSettingsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionSettingsState.swift; sourceTree = "<group>"; };
 		63CC34652531982E00466679 /* SafariExtensionSettingsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionSettingsAdapter.swift; sourceTree = "<group>"; };
 		63CC34662531982E00466679 /* CCS22SafariExtensionSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCS22SafariExtensionSettingsTests.swift; sourceTree = "<group>"; };
+		63CC34672531982E00466679 /* SafariExtensionSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionSettingsViewModel.swift; sourceTree = "<group>"; };
 		625712E62371982E00466679 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		625712F62371982E00466679 /* CurrencyConverter Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CurrencyConverter Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		625712FB2371982E00466679 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -247,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				63CC34602531982E00466679 /* SafariExtensionSettingsState.swift */,
+				63CC34672531982E00466679 /* SafariExtensionSettingsViewModel.swift */,
 				63CC34502531982E00466679 /* AtomicRenew.swift */,
 				63CC34122531982E00466679 /* ConvertHistoryUIBeanProduction.swift */,
 				63CC34002371982E00466679 /* LegacyContractSeams.swift */,
@@ -433,6 +437,7 @@
 			files = (
 				63CC34642531982E00466679 /* CCS22SafariExtensionSettingsTests.swift in Sources */,
 				63CC34622531982E00466679 /* SafariExtensionSettingsState.swift in Sources */,
+				63CC34692531982E00466679 /* SafariExtensionSettingsViewModel.swift in Sources */,
 				62B81E67254240C70015CC19 /* CreditCardProfile.swift in Sources */,
 				62B81E4A2542155D0015CC19 /* CurrencySymbolMap.swift in Sources */,
 				6257132323719BDC00466679 /* SharedPersistent.swift in Sources */,
@@ -478,6 +483,7 @@
 			files = (
 				63CC34632531982E00466679 /* SafariExtensionSettingsAdapter.swift in Sources */,
 				63CC34622531982E00466679 /* SafariExtensionSettingsState.swift in Sources */,
+				63CC34682531982E00466679 /* SafariExtensionSettingsViewModel.swift in Sources */,
 				6262F06925220FA90066ADFA /* SharedPersistent.swift in Sources */,
 				6262F07F252226100066ADFA /* PreviewConvertHistory.swift in Sources */,
 				621C84462537492900DC7ECC /* ApiSyncInfoViewModel.swift in Sources */,

--- a/CurrencyConverter.xcodeproj/project.pbxproj
+++ b/CurrencyConverter.xcodeproj/project.pbxproj
@@ -482,7 +482,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63CC34632531982E00466679 /* SafariExtensionSettingsAdapter.swift in Sources */,
-				63CC34622531982E00466679 /* SafariExtensionSettingsState.swift in Sources */,
+				63CC34612531982E00466679 /* SafariExtensionSettingsState.swift in Sources */,
 				63CC34682531982E00466679 /* SafariExtensionSettingsViewModel.swift in Sources */,
 				6262F06925220FA90066ADFA /* SharedPersistent.swift in Sources */,
 				6262F07F252226100066ADFA /* PreviewConvertHistory.swift in Sources */,

--- a/CurrencyConverter/AppDelegate.swift
+++ b/CurrencyConverter/AppDelegate.swift
@@ -13,6 +13,7 @@ import SwiftUI
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     var window: NSWindow!
+    private let extensionSettingsViewModel = SafariExtensionSettingsViewModel(provider: SafariExtensionSettingsAdapter())
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
@@ -22,7 +23,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Create the SwiftUI view and set the context as the value for the managedObjectContext environment keyPath.
         // Add `@Environment(\.managedObjectContext)` in the views that will need the context.
-        let contentView = ContentView().environment(\.managedObjectContext, persistentContainer.viewContext)
+        let contentView = ContentView(extensionSettings: extensionSettingsViewModel)
+            .environment(\.managedObjectContext, persistentContainer.viewContext)
 
         // Create the window and set the content view.
         window = NSWindow(
@@ -137,4 +139,3 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
 }
-

--- a/CurrencyConverter/ContentView.swift
+++ b/CurrencyConverter/ContentView.swift
@@ -7,11 +7,11 @@
 //
 
 import SwiftUI
-import SafariServices
 
 struct ContentView: View {
     
     @ObservedObject var dataset = ConvertHistoryDMCollection()
+    @ObservedObject private var extensionSettings = SafariExtensionSettingsViewModel()
     @State var showInstallButton = true
     @State var currentTab = 0
     
@@ -45,18 +45,25 @@ struct ContentView: View {
                     }.padding(.all, 5)
                     Spacer()
                     if self.showInstallButton {
-                        Button("Enable/Disable Extension") {
-                            SFSafariApplication.showPreferencesForExtension(withIdentifier: "com.rayer.CurrencyConverter-Extension") { error in
-                                if let e = error {
-                                    // Insert code to inform the user that something went wrong.
-                                    print("Error opening preference for extension : \(e)")
-                                }
+                        VStack(alignment: .trailing, spacing: 4) {
+                            Text(extensionSettings.copy.statusText)
+                                .font(.caption)
+                                .multilineTextAlignment(.trailing)
+                                .accessibility(label: Text("Safari extension status"))
+                                .accessibility(value: Text(extensionSettings.copy.accessibilityValue))
+                            Button(extensionSettings.copy.actionTitle) {
+                                extensionSettings.openSettings()
                             }
-                            
-                        }.padding(.all, 5)
+                            .accessibility(hint: Text(extensionSettings.copy.accessibilityHint))
+                        }
+                        .padding(.all, 5)
                     }
                 }
-            }.tabItem {
+            }
+            .onAppear {
+                extensionSettings.refresh()
+            }
+            .tabItem {
                 Text("Stored Records")
                 
             }.tag(0)

--- a/CurrencyConverter/ContentView.swift
+++ b/CurrencyConverter/ContentView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Rayer. All rights reserved.
 //
 
+import AppKit
 import SwiftUI
 
 struct ContentView: View {
@@ -61,6 +62,9 @@ struct ContentView: View {
                 }
             }
             .onAppear {
+                extensionSettings.refresh()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 extensionSettings.refresh()
             }
             .tabItem {

--- a/CurrencyConverter/ContentView.swift
+++ b/CurrencyConverter/ContentView.swift
@@ -12,11 +12,12 @@ import SwiftUI
 struct ContentView: View {
     
     @ObservedObject var dataset = ConvertHistoryDMCollection()
-    @ObservedObject private var extensionSettings = SafariExtensionSettingsViewModel()
+    @ObservedObject private var extensionSettings: SafariExtensionSettingsViewModel
     @State var showInstallButton = true
     @State var currentTab = 0
     
-    init() {
+    init(extensionSettings: SafariExtensionSettingsViewModel) {
+        _extensionSettings = ObservedObject(wrappedValue: extensionSettings)
         NotificationCenter.default.addObserver(dataset, selector: #selector(type(of: dataset).reload), name: .NSPersistentStoreRemoteChange, object: sharedPersistentContainer.persistentStoreCoordinator)
         dataset.reload()
     }
@@ -98,6 +99,16 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
 
     static var previews: some View {
-        ContentView()
+        ContentView(extensionSettings: SafariExtensionSettingsViewModel(provider: PreviewSafariExtensionSettingsProvider()))
+    }
+}
+
+private struct PreviewSafariExtensionSettingsProvider: SafariExtensionSettingsProviding {
+    func fetchState(completion: @escaping (SafariExtensionSettingsResult) -> Void) {
+        completion(.status(.unknown))
+    }
+
+    func openSettings(completion: @escaping (String?) -> Void) {
+        completion(nil)
     }
 }

--- a/CurrencyConverter/SafariExtensionSettingsAdapter.swift
+++ b/CurrencyConverter/SafariExtensionSettingsAdapter.swift
@@ -1,0 +1,117 @@
+import Combine
+import Foundation
+import SafariServices
+
+protocol SafariExtensionSettingsProviding {
+    func fetchState(completion: @escaping (SafariExtensionSettingsResult) -> Void)
+    func openSettings(completion: @escaping (String?) -> Void)
+}
+
+final class SafariExtensionSettingsAdapter: SafariExtensionSettingsProviding {
+    private static let extensionProductName = "CurrencyConverter Extension"
+
+    private let extensionBundleIdentifier: String?
+
+    init(bundle: Bundle = .main) {
+        extensionBundleIdentifier = Self.configuredExtensionBundleIdentifier(in: bundle)
+    }
+
+    static func configuredExtensionBundleIdentifier(in bundle: Bundle) -> String? {
+        guard let plugInsURL = bundle.builtInPlugInsURL else { return nil }
+        let extensionURL = plugInsURL.appendingPathComponent("\(extensionProductName).appex", isDirectory: true)
+        return Bundle(url: extensionURL)?.bundleIdentifier
+    }
+
+    func fetchState(completion: @escaping (SafariExtensionSettingsResult) -> Void) {
+        guard let identifier = extensionBundleIdentifier else {
+            publish(.failure("The bundled Safari extension identifier is unavailable."), completion: completion)
+            return
+        }
+
+        SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: identifier) { state, error in
+            let result: SafariExtensionSettingsResult
+            if let error = error {
+                result = .failure("Unable to read Safari extension status: \(error.localizedDescription)")
+            } else if let state = state {
+                result = .status(state.isEnabled ? .enabled : .disabled)
+            } else {
+                result = .status(.unknown)
+            }
+            self.publish(result, completion: completion)
+        }
+    }
+
+    func openSettings(completion: @escaping (String?) -> Void) {
+        guard let identifier = extensionBundleIdentifier else {
+            publish("The bundled Safari extension identifier is unavailable.", completion: completion)
+            return
+        }
+
+        SFSafariApplication.showPreferencesForExtension(withIdentifier: identifier) { error in
+            self.publish(error.map { "Unable to open Safari Extension Settings: \($0.localizedDescription)" }, completion: completion)
+        }
+    }
+
+    private func publish<T>(_ value: T, completion: @escaping (T) -> Void) {
+        if Thread.isMainThread {
+            completion(value)
+        } else {
+            DispatchQueue.main.async {
+                completion(value)
+            }
+        }
+    }
+}
+
+final class SafariExtensionSettingsViewModel: ObservableObject {
+    @Published private(set) var copy = SafariExtensionSettingsCopyMapping.copy(for: .loading)
+
+    private let provider: SafariExtensionSettingsProviding
+    private var stateMachine = SafariExtensionSettingsStateMachine()
+
+    init(provider: SafariExtensionSettingsProviding = SafariExtensionSettingsAdapter()) {
+        self.provider = provider
+    }
+
+    func refresh() {
+        let generation = stateMachine.beginRefresh()
+        publishCopy()
+        provider.fetchState { [weak self] result in
+            self?.apply(result, for: generation)
+        }
+    }
+
+    func openSettings() {
+        let generation = stateMachine.beginHandoff()
+        provider.openSettings { [weak self] errorMessage in
+            guard let self = self else { return }
+            self.onMain {
+                if let errorMessage = errorMessage {
+                    guard self.stateMachine.apply(.failure(errorMessage), for: generation) else { return }
+                    self.publishCopy()
+                } else {
+                    self.refresh()
+                }
+            }
+        }
+    }
+
+    private func apply(_ result: SafariExtensionSettingsResult, for generation: UInt) {
+        onMain {
+            guard self.stateMachine.apply(result, for: generation) else { return }
+            self.publishCopy()
+        }
+    }
+
+    private func publishCopy() {
+        copy = SafariExtensionSettingsCopyMapping.copy(for: stateMachine.status)
+    }
+
+    private func onMain(_ action: @escaping () -> Void) {
+        if Thread.isMainThread {
+            action()
+        } else {
+            DispatchQueue.main.async(execute: action)
+        }
+    }
+}

--- a/CurrencyConverter/SafariExtensionSettingsAdapter.swift
+++ b/CurrencyConverter/SafariExtensionSettingsAdapter.swift
@@ -1,11 +1,5 @@
-import Combine
 import Foundation
 import SafariServices
-
-protocol SafariExtensionSettingsProviding {
-    func fetchState(completion: @escaping (SafariExtensionSettingsResult) -> Void)
-    func openSettings(completion: @escaping (String?) -> Void)
-}
 
 final class SafariExtensionSettingsAdapter: SafariExtensionSettingsProviding {
     private static let extensionProductName = "CurrencyConverter Extension"
@@ -59,59 +53,6 @@ final class SafariExtensionSettingsAdapter: SafariExtensionSettingsProviding {
             DispatchQueue.main.async {
                 completion(value)
             }
-        }
-    }
-}
-
-final class SafariExtensionSettingsViewModel: ObservableObject {
-    @Published private(set) var copy = SafariExtensionSettingsCopyMapping.copy(for: .loading)
-
-    private let provider: SafariExtensionSettingsProviding
-    private var stateMachine = SafariExtensionSettingsStateMachine()
-
-    init(provider: SafariExtensionSettingsProviding = SafariExtensionSettingsAdapter()) {
-        self.provider = provider
-    }
-
-    func refresh() {
-        let generation = stateMachine.beginRefresh()
-        publishCopy()
-        provider.fetchState { [weak self] result in
-            self?.apply(result, for: generation)
-        }
-    }
-
-    func openSettings() {
-        let generation = stateMachine.beginHandoff()
-        provider.openSettings { [weak self] errorMessage in
-            guard let self = self else { return }
-            self.onMain {
-                if let errorMessage = errorMessage {
-                    guard self.stateMachine.apply(.failure(errorMessage), for: generation) else { return }
-                    self.publishCopy()
-                } else {
-                    self.refresh()
-                }
-            }
-        }
-    }
-
-    private func apply(_ result: SafariExtensionSettingsResult, for generation: UInt) {
-        onMain {
-            guard self.stateMachine.apply(result, for: generation) else { return }
-            self.publishCopy()
-        }
-    }
-
-    private func publishCopy() {
-        copy = SafariExtensionSettingsCopyMapping.copy(for: stateMachine.status)
-    }
-
-    private func onMain(_ action: @escaping () -> Void) {
-        if Thread.isMainThread {
-            action()
-        } else {
-            DispatchQueue.main.async(execute: action)
         }
     }
 }

--- a/CurrencyConverterTests/CCS22SafariExtensionSettingsTests.swift
+++ b/CurrencyConverterTests/CCS22SafariExtensionSettingsTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import CurrencyConverter
+
+final class CCS22SafariExtensionSettingsTests: XCTestCase {
+    func testCopyNeverPromisesDirectToggleAndDescribesManualSettings() {
+        let copy = SafariExtensionSettingsCopyMapping.copy(for: .disabled)
+
+        XCTAssertEqual(copy.actionTitle, "Open Safari Extension Settings")
+        XCTAssertTrue(copy.statusText.contains("Enable it in Safari Extension Settings"))
+        XCTAssertTrue(copy.accessibilityHint.contains("Enable or disable it there"))
+        XCTAssertFalse(copy.actionTitle.contains("Enable/Disable"))
+    }
+
+    func testCopyMapsLoadingUnknownEnabledDisabledAndError() {
+        XCTAssertEqual(SafariExtensionSettingsCopyMapping.copy(for: .loading).accessibilityValue, "Checking.")
+        XCTAssertEqual(SafariExtensionSettingsCopyMapping.copy(for: .unknown).accessibilityValue, "Unknown.")
+        XCTAssertEqual(SafariExtensionSettingsCopyMapping.copy(for: .enabled).accessibilityValue, "Enabled.")
+        XCTAssertEqual(SafariExtensionSettingsCopyMapping.copy(for: .disabled).accessibilityValue, "Disabled.")
+        XCTAssertTrue(SafariExtensionSettingsCopyMapping.copy(for: .error("open failed")).statusText.contains("open failed"))
+    }
+
+    func testFailureIsVisibleInStateAndCopy() {
+        var machine = SafariExtensionSettingsStateMachine()
+        let generation = machine.beginHandoff()
+
+        XCTAssertTrue(machine.apply(.failure("Safari is unavailable"), for: generation))
+        XCTAssertEqual(machine.status, .error("Safari is unavailable"))
+        XCTAssertTrue(SafariExtensionSettingsCopyMapping.copy(for: machine.status).statusText.contains("Safari is unavailable"))
+    }
+
+    func testStaleGenerationCannotOverwriteCurrentState() {
+        var machine = SafariExtensionSettingsStateMachine()
+        let firstGeneration = machine.beginRefresh()
+        let currentGeneration = machine.beginRefresh()
+
+        XCTAssertFalse(machine.apply(.status(.enabled), for: firstGeneration))
+        XCTAssertEqual(machine.status, .loading)
+        XCTAssertTrue(machine.apply(.status(.disabled), for: currentGeneration))
+        XCTAssertEqual(machine.status, .disabled)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Safari App Extension跟以前的Safari Extension不同，他**無法**單獨安�
 
 1. 從[Release頁面](https://github.com/Rayer/CurrencyConverter/releases)下載`CurrencyConverter.app.zip`，目前版本是1.5。預設我放上去的版本都是開發者簽名過且AppConnect認證過的application。
 2. 就像普通macOS App一樣，把他丟進Application
-3. 執行App，按下Enable/Disable extension。如果沒有反應的話，請打開Safari -> Preference -> Extensions，啟動CurrencyConverter。
-4. 他會自動打開Safari Preference，把Plugin的CurrencyConverter打勾即可。
+3. 執行App，按下`Open Safari Extension Settings`。App只能開啟Safari的Extension設定，不能直接替你切換開關。
+4. Safari設定會選取CurrencyConverter；在Safari的`Settings -> Extensions`中手動啟用或停用它，然後回到App查看狀態。
 
 
 ## 主要功能

--- a/Scripts/ccs22_standalone_tests.swift
+++ b/Scripts/ccs22_standalone_tests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 func require(_ condition: @autoclosure () -> Bool, _ message: String) {
@@ -7,27 +8,128 @@ func require(_ condition: @autoclosure () -> Bool, _ message: String) {
     }
 }
 
+final class FakeSafariExtensionSettingsProvider: SafariExtensionSettingsProviding {
+    private(set) var fetchCompletions: [(SafariExtensionSettingsResult) -> Void] = []
+    private(set) var openSettingsCompletions: [(String?) -> Void] = []
+
+    func fetchState(completion: @escaping (SafariExtensionSettingsResult) -> Void) {
+        fetchCompletions.append(completion)
+    }
+
+    func openSettings(completion: @escaping (String?) -> Void) {
+        openSettingsCompletions.append(completion)
+    }
+}
+
+func waitForMainQueue(until condition: @escaping () -> Bool, _ message: String) {
+    let deadline = Date(timeIntervalSinceNow: 2)
+    while !condition() && Date() < deadline {
+        RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.01))
+    }
+    require(condition(), message)
+}
+
+func testBackgroundRefreshPublishesOnMain() {
+    let provider = FakeSafariExtensionSettingsProvider()
+    let viewModel = SafariExtensionSettingsViewModel(provider: provider)
+    var enabledCopyPublishedOnMain = false
+    let cancellable = viewModel.$copy.sink { copy in
+        if copy.accessibilityValue == "Enabled." {
+            enabledCopyPublishedOnMain = Thread.isMainThread
+        }
+    }
+
+    viewModel.refresh()
+    require(provider.fetchCompletions.count == 1, "refresh must ask the provider for state")
+    let completion = provider.fetchCompletions[0]
+    DispatchQueue.global().async {
+        completion(.status(.enabled))
+    }
+    waitForMainQueue(until: { viewModel.copy.accessibilityValue == "Enabled." }, "background refresh callback must publish")
+    require(enabledCopyPublishedOnMain, "background refresh callback must publish copy on main")
+    _ = cancellable
+}
+
+func testOpenSettingsErrorIsVisible() {
+    let provider = FakeSafariExtensionSettingsProvider()
+    let viewModel = SafariExtensionSettingsViewModel(provider: provider)
+
+    viewModel.openSettings()
+    require(provider.openSettingsCompletions.count == 1, "open settings must ask the provider")
+    provider.openSettingsCompletions[0]("Safari is unavailable")
+
+    require(viewModel.copy.statusText.contains("Safari is unavailable"), "open settings error must be visible")
+}
+
+func testSuccessfulHandoffTriggersRefresh() {
+    let provider = FakeSafariExtensionSettingsProvider()
+    let viewModel = SafariExtensionSettingsViewModel(provider: provider)
+
+    viewModel.openSettings()
+    provider.openSettingsCompletions[0](nil)
+    require(provider.fetchCompletions.count == 1, "successful settings handoff must refresh state")
+
+    provider.fetchCompletions[0](.status(.enabled))
+    require(viewModel.copy.accessibilityValue == "Enabled.", "handoff refresh result must be visible")
+}
+
+func testStaleOutOfOrderCallbacksCannotOverwriteLatestState() {
+    let provider = FakeSafariExtensionSettingsProvider()
+    let viewModel = SafariExtensionSettingsViewModel(provider: provider)
+
+    viewModel.refresh()
+    viewModel.refresh()
+    require(provider.fetchCompletions.count == 2, "duplicate refreshes must remain independently controllable")
+
+    provider.fetchCompletions[1](.status(.disabled))
+    let staleCompletion = provider.fetchCompletions[0]
+    DispatchQueue.global().sync {
+        staleCompletion(.status(.enabled))
+    }
+    var mainQueueDrained = false
+    DispatchQueue.main.async {
+        mainQueueDrained = true
+    }
+    waitForMainQueue(until: { mainQueueDrained }, "stale callback must reach main queue")
+    require(viewModel.copy.accessibilityValue == "Disabled.", "stale callback must not overwrite latest state")
+}
+
+func testDuplicateActivationRefreshIsGenerationSafe() {
+    let provider = FakeSafariExtensionSettingsProvider()
+    let viewModel = SafariExtensionSettingsViewModel(provider: provider)
+
+    viewModel.refresh()
+    viewModel.refresh()
+    provider.fetchCompletions[0](.status(.enabled))
+    require(viewModel.copy.accessibilityValue == "Checking.", "first activation callback must be stale")
+    provider.fetchCompletions[1](.status(.disabled))
+    require(viewModel.copy.accessibilityValue == "Disabled.", "latest activation callback must win")
+}
+
+func testPureStateAndCopyBehavior() {
+    let disabledCopy = SafariExtensionSettingsCopyMapping.copy(for: .disabled)
+    require(disabledCopy.actionTitle == "Open Safari Extension Settings", "action copy must describe settings")
+    require(!disabledCopy.actionTitle.contains("Enable/Disable"), "action copy must not promise a toggle")
+    require(disabledCopy.accessibilityHint.contains("Enable or disable it there"), "manual Safari step must be accessible")
+
+    var machine = SafariExtensionSettingsStateMachine()
+    let firstGeneration = machine.beginRefresh()
+    let currentGeneration = machine.beginRefresh()
+    require(!machine.apply(.status(.enabled), for: firstGeneration), "stale callback must be ignored")
+    require(machine.status == .loading, "stale callback must not change loading state")
+    require(machine.apply(.status(.disabled), for: currentGeneration), "current callback must apply")
+    require(machine.status == .disabled, "disabled state must be observable")
+}
+
 @main
 struct CCS22StandaloneTests {
     static func main() {
-        let disabledCopy = SafariExtensionSettingsCopyMapping.copy(for: .disabled)
-        require(disabledCopy.actionTitle == "Open Safari Extension Settings", "action copy must describe settings")
-        require(!disabledCopy.actionTitle.contains("Enable/Disable"), "action copy must not promise a toggle")
-        require(disabledCopy.accessibilityHint.contains("Enable or disable it there"), "manual Safari step must be accessible")
-
-        var machine = SafariExtensionSettingsStateMachine()
-        let firstGeneration = machine.beginRefresh()
-        let currentGeneration = machine.beginRefresh()
-        require(!machine.apply(.status(.enabled), for: firstGeneration), "stale callback must be ignored")
-        require(machine.status == .loading, "stale callback must not change loading state")
-        require(machine.apply(.status(.disabled), for: currentGeneration), "current callback must apply")
-        require(machine.status == .disabled, "disabled state must be observable")
-
-        let errorGeneration = machine.beginHandoff()
-        require(machine.apply(.failure("settings handoff failed"), for: errorGeneration), "failure must apply")
-        require(machine.status == .error("settings handoff failed"), "error state must be observable")
-        require(SafariExtensionSettingsCopyMapping.copy(for: machine.status).statusText.contains("settings handoff failed"), "error must reach user copy")
-
-        print("CCS-22 standalone state/copy/generation checks passed")
+        testPureStateAndCopyBehavior()
+        testBackgroundRefreshPublishesOnMain()
+        testOpenSettingsErrorIsVisible()
+        testSuccessfulHandoffTriggersRefresh()
+        testStaleOutOfOrderCallbacksCannotOverwriteLatestState()
+        testDuplicateActivationRefreshIsGenerationSafe()
+        print("CCS-22 standalone state/copy/ViewModel/provider checks passed (6 integration/state cases)")
     }
 }

--- a/Scripts/ccs22_standalone_tests.swift
+++ b/Scripts/ccs22_standalone_tests.swift
@@ -73,6 +73,20 @@ func testSuccessfulHandoffTriggersRefresh() {
     require(viewModel.copy.accessibilityValue == "Enabled.", "handoff refresh result must be visible")
 }
 
+func testStaleSuccessfulHandoffCannotTriggerRefresh() {
+    let provider = FakeSafariExtensionSettingsProvider()
+    let viewModel = SafariExtensionSettingsViewModel(provider: provider)
+
+    viewModel.openSettings()
+    viewModel.openSettings()
+    require(provider.openSettingsCompletions.count == 2, "overlapping handoffs must remain independently controllable")
+
+    provider.openSettingsCompletions[0](nil)
+    require(provider.fetchCompletions.isEmpty, "stale successful handoff must not start a refresh")
+    provider.openSettingsCompletions[1](nil)
+    require(provider.fetchCompletions.count == 1, "current successful handoff must start one refresh")
+}
+
 func testStaleOutOfOrderCallbacksCannotOverwriteLatestState() {
     let provider = FakeSafariExtensionSettingsProvider()
     let viewModel = SafariExtensionSettingsViewModel(provider: provider)
@@ -128,8 +142,9 @@ struct CCS22StandaloneTests {
         testBackgroundRefreshPublishesOnMain()
         testOpenSettingsErrorIsVisible()
         testSuccessfulHandoffTriggersRefresh()
+        testStaleSuccessfulHandoffCannotTriggerRefresh()
         testStaleOutOfOrderCallbacksCannotOverwriteLatestState()
         testDuplicateActivationRefreshIsGenerationSafe()
-        print("CCS-22 standalone state/copy/ViewModel/provider checks passed (6 integration/state cases)")
+        print("CCS-22 standalone state/copy/ViewModel/provider checks passed (7 integration/state cases)")
     }
 }

--- a/Scripts/ccs22_standalone_tests.swift
+++ b/Scripts/ccs22_standalone_tests.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        FileHandle.standardError.write(Data("FAIL: \(message)\n".utf8))
+        exit(1)
+    }
+}
+
+@main
+struct CCS22StandaloneTests {
+    static func main() {
+        let disabledCopy = SafariExtensionSettingsCopyMapping.copy(for: .disabled)
+        require(disabledCopy.actionTitle == "Open Safari Extension Settings", "action copy must describe settings")
+        require(!disabledCopy.actionTitle.contains("Enable/Disable"), "action copy must not promise a toggle")
+        require(disabledCopy.accessibilityHint.contains("Enable or disable it there"), "manual Safari step must be accessible")
+
+        var machine = SafariExtensionSettingsStateMachine()
+        let firstGeneration = machine.beginRefresh()
+        let currentGeneration = machine.beginRefresh()
+        require(!machine.apply(.status(.enabled), for: firstGeneration), "stale callback must be ignored")
+        require(machine.status == .loading, "stale callback must not change loading state")
+        require(machine.apply(.status(.disabled), for: currentGeneration), "current callback must apply")
+        require(machine.status == .disabled, "disabled state must be observable")
+
+        let errorGeneration = machine.beginHandoff()
+        require(machine.apply(.failure("settings handoff failed"), for: errorGeneration), "failure must apply")
+        require(machine.status == .error("settings handoff failed"), "error state must be observable")
+        require(SafariExtensionSettingsCopyMapping.copy(for: machine.status).statusText.contains("settings handoff failed"), "error must reach user copy")
+
+        print("CCS-22 standalone state/copy/generation checks passed")
+    }
+}

--- a/Scripts/verify-ccs22.sh
+++ b/Scripts/verify-ccs22.sh
@@ -33,7 +33,8 @@ fi
 if rg -q 'com\.rayer\.CurrencyConverter-Extension' CurrencyConverter Shared; then
     fail "extension bundle identifier is duplicated in Swift"
 fi
-test "$(rg -c '^[[:space:]]+63CC34622531982E00466679 .*SafariExtensionSettingsState.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 2 || fail "state seam is not in app and test targets"
+test "$(rg -c '^[[:space:]]+63CC34612531982E00466679 .*SafariExtensionSettingsState.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 1 || fail "state seam app build file is missing or reused"
+test "$(rg -c '^[[:space:]]+63CC34622531982E00466679 .*SafariExtensionSettingsState.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 1 || fail "state seam test build file is missing or reused"
 test "$(rg -c '^[[:space:]]+63CC346[89]2531982E00466679 .*SafariExtensionSettingsViewModel.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 2 || fail "shared ViewModel is not in app and test targets"
 app_sources=$(awk '/62850394251B936F00E381AA \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)
 test_sources=$(awk '/625712DC2371982E00466679 \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)

--- a/Scripts/verify-ccs22.sh
+++ b/Scripts/verify-ccs22.sh
@@ -18,23 +18,43 @@ fi
 rg -q 'SFSafariApplication\.showPreferencesForExtension\(withIdentifier: identifier' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "settings API wiring is missing"
 rg -q 'SFSafariExtensionManager\.getStateOfSafariExtension\(withIdentifier: identifier\)' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "state API wiring is missing"
 rg -q 'builtInPlugInsURL' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "configured embedded extension lookup is missing"
+rg -Fq 'appendingPathComponent("\(extensionProductName).appex", isDirectory: true)' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "exact embedded extension lookup is missing"
 rg -q 'NSApplication\.didBecomeActiveNotification' CurrencyConverter/ContentView.swift || fail "state is not refreshed when the user returns from Safari"
+rg -q 'private let extensionSettingsViewModel = SafariExtensionSettingsViewModel\(provider: SafariExtensionSettingsAdapter\(\)\)' CurrencyConverter/AppDelegate.swift || fail "AppDelegate does not strongly own the production ViewModel"
+rg -q 'ContentView\(extensionSettings: extensionSettingsViewModel\)' CurrencyConverter/AppDelegate.swift || fail "AppDelegate does not inject its stable ViewModel"
+rg -q '@ObservedObject private var extensionSettings: SafariExtensionSettingsViewModel' CurrencyConverter/ContentView.swift || fail "ContentView does not observe the injected ViewModel"
+rg -q '_extensionSettings = ObservedObject\(wrappedValue: extensionSettings\)' CurrencyConverter/ContentView.swift || fail "ContentView does not retain the injected observed instance"
+if rg -q '@ObservedObject[^\n]*= SafariExtensionSettingsViewModel' CurrencyConverter/ContentView.swift; then
+    fail "ContentView still creates a replacement ViewModel"
+fi
+if rg -q '@StateObject' CurrencyConverter Shared; then
+    fail "macOS 10.15-incompatible StateObject ownership was introduced"
+fi
 if rg -q 'com\.rayer\.CurrencyConverter-Extension' CurrencyConverter Shared; then
     fail "extension bundle identifier is duplicated in Swift"
 fi
-test "$(rg -c '^[[:space:]]+63CC34622531982E00466679 .*SafariExtensionSettingsState.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 2 || fail "Foundation seam is not in app and test targets"
+test "$(rg -c '^[[:space:]]+63CC34622531982E00466679 .*SafariExtensionSettingsState.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 2 || fail "state seam is not in app and test targets"
+test "$(rg -c '^[[:space:]]+63CC346[89]2531982E00466679 .*SafariExtensionSettingsViewModel.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 2 || fail "shared ViewModel is not in app and test targets"
 app_sources=$(awk '/62850394251B936F00E381AA \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)
 test_sources=$(awk '/625712DC2371982E00466679 \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)
 extension_sources=$(awk '/625712F22371982E00466679 \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)
 printf '%s\n' "$app_sources" | rg -q 'SafariExtensionSettingsAdapter.swift in Sources' || fail "SafariServices adapter is not in the app target"
 printf '%s\n' "$app_sources" | rg -q 'SafariExtensionSettingsState.swift in Sources' || fail "Foundation seam is not in the app target"
+printf '%s\n' "$app_sources" | rg -q 'SafariExtensionSettingsViewModel.swift in Sources' || fail "shared ViewModel is not in the app target"
 printf '%s\n' "$test_sources" | rg -q 'SafariExtensionSettingsState.swift in Sources' || fail "Foundation seam is not in the test target"
+printf '%s\n' "$test_sources" | rg -q 'SafariExtensionSettingsViewModel.swift in Sources' || fail "shared ViewModel is not in the test target"
 printf '%s\n' "$test_sources" | rg -q 'CCS22SafariExtensionSettingsTests.swift in Sources' || fail "CCS-22 tests are not in the test target"
+if printf '%s\n' "$test_sources" | rg -q 'SafariExtensionSettingsAdapter.swift|ContentView.swift|AppDelegate.swift'; then
+    fail "SwiftUI app or SafariServices adapter leaked into the test target"
+fi
 if printf '%s\n' "$extension_sources" | rg -q 'SafariExtensionSettings'; then
     fail "SafariServices app adapter or seam leaked into the extension target"
 fi
 if rg -q 'SafariServices' Shared; then
     fail "Foundation-only shared seam imports SafariServices"
+fi
+if rg -q 'SwiftUI|AppKit|SafariServices' Shared/SafariExtensionSettingsViewModel.swift Scripts/ccs22_standalone_tests.swift; then
+    fail "standalone ViewModel tests link UI or SafariServices implementation"
 fi
 if rg -q 'TEST_HOST|BUNDLE_LOADER' CurrencyConverter.xcodeproj; then
     fail "test host regression detected"
@@ -44,6 +64,7 @@ extension_id=$(sed -n 's/^[[:space:]]*PRODUCT_BUNDLE_IDENTIFIER = "\([^"]*\)";/\
 test -n "$extension_id" || fail "extension bundle identifier is missing from project settings"
 test "$extension_id" = "com.rayer.CurrencyConverter-Extension" || fail "unexpected configured extension bundle identifier"
 rg -q 'CurrencyConverter Extension\.appex' CurrencyConverter.xcodeproj/project.pbxproj || fail "extension is not embedded in the app"
+rg -q 'cannot directly switch|不能直接替你切換開關' README.md || fail "manual Safari runtime gate is not documented"
 
 temporary_dir=$(mktemp -d)
 trap 'rm -rf "$temporary_dir"' EXIT HUP INT TERM
@@ -52,6 +73,6 @@ if [ -z "$swiftc_path" ]; then
     swiftc_path=$(DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" xcrun --sdk macosx --find swiftc)
 fi
 sdk_path=$(DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" xcrun --sdk macosx --show-sdk-path)
-"$swiftc_path" -sdk "$sdk_path" Shared/SafariExtensionSettingsState.swift Scripts/ccs22_standalone_tests.swift -o "$temporary_dir/ccs22_standalone_tests"
+"$swiftc_path" -sdk "$sdk_path" Shared/SafariExtensionSettingsState.swift Shared/SafariExtensionSettingsViewModel.swift Scripts/ccs22_standalone_tests.swift -o "$temporary_dir/ccs22_standalone_tests"
 "$temporary_dir/ccs22_standalone_tests"
 echo "CCS-22 static wiring checks passed"

--- a/Scripts/verify-ccs22.sh
+++ b/Scripts/verify-ccs22.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root"
+
+fail() {
+    echo "CCS-22 verification failed: $1" >&2
+    exit 1
+}
+
+command -v rg >/dev/null 2>&1 || fail "rg is required"
+
+rg -q 'Open Safari Extension Settings' CurrencyConverter/ContentView.swift README.md || fail "truthful settings copy is missing"
+if rg -q 'Enable/Disable Extension|Enable/Disable extension' CurrencyConverter README.md; then
+    fail "direct-toggle copy remains in app or README"
+fi
+rg -q 'SFSafariApplication\.showPreferencesForExtension\(withIdentifier: identifier' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "settings API wiring is missing"
+rg -q 'SFSafariExtensionManager\.getStateOfSafariExtension\(withIdentifier: identifier\)' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "state API wiring is missing"
+rg -q 'builtInPlugInsURL' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "configured embedded extension lookup is missing"
+if rg -q 'com\.rayer\.CurrencyConverter-Extension' CurrencyConverter Shared; then
+    fail "extension bundle identifier is duplicated in Swift"
+fi
+test "$(rg -c '^[[:space:]]+63CC34622531982E00466679 .*SafariExtensionSettingsState.swift in Sources.*,$' CurrencyConverter.xcodeproj/project.pbxproj)" = 2 || fail "Foundation seam is not in app and test targets"
+app_sources=$(awk '/62850394251B936F00E381AA \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)
+test_sources=$(awk '/625712DC2371982E00466679 \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)
+extension_sources=$(awk '/625712F22371982E00466679 \/\* Sources \*\/ =/ {in_sources=1} in_sources {print} in_sources && /runOnlyForDeploymentPostprocessing = 0;/ {exit}' CurrencyConverter.xcodeproj/project.pbxproj)
+printf '%s\n' "$app_sources" | rg -q 'SafariExtensionSettingsAdapter.swift in Sources' || fail "SafariServices adapter is not in the app target"
+printf '%s\n' "$app_sources" | rg -q 'SafariExtensionSettingsState.swift in Sources' || fail "Foundation seam is not in the app target"
+printf '%s\n' "$test_sources" | rg -q 'SafariExtensionSettingsState.swift in Sources' || fail "Foundation seam is not in the test target"
+printf '%s\n' "$test_sources" | rg -q 'CCS22SafariExtensionSettingsTests.swift in Sources' || fail "CCS-22 tests are not in the test target"
+if printf '%s\n' "$extension_sources" | rg -q 'SafariExtensionSettings'; then
+    fail "SafariServices app adapter or seam leaked into the extension target"
+fi
+if rg -q 'SafariServices' Shared; then
+    fail "Foundation-only shared seam imports SafariServices"
+fi
+if rg -q 'TEST_HOST|BUNDLE_LOADER' CurrencyConverter.xcodeproj; then
+    fail "test host regression detected"
+fi
+
+extension_id=$(sed -n 's/^[[:space:]]*PRODUCT_BUNDLE_IDENTIFIER = "\([^"]*\)";/\1/p' CurrencyConverter.xcodeproj/project.pbxproj | head -1)
+test -n "$extension_id" || fail "extension bundle identifier is missing from project settings"
+test "$extension_id" = "com.rayer.CurrencyConverter-Extension" || fail "unexpected configured extension bundle identifier"
+rg -q 'CurrencyConverter Extension\.appex' CurrencyConverter.xcodeproj/project.pbxproj || fail "extension is not embedded in the app"
+
+temporary_dir=$(mktemp -d)
+trap 'rm -rf "$temporary_dir"' EXIT HUP INT TERM
+swiftc_path=${SWIFTC:-}
+if [ -z "$swiftc_path" ]; then
+    swiftc_path=$(DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" xcrun --sdk macosx --find swiftc)
+fi
+sdk_path=$(DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" xcrun --sdk macosx --show-sdk-path)
+"$swiftc_path" -sdk "$sdk_path" Shared/SafariExtensionSettingsState.swift Scripts/ccs22_standalone_tests.swift -o "$temporary_dir/ccs22_standalone_tests"
+"$temporary_dir/ccs22_standalone_tests"
+echo "CCS-22 static wiring checks passed"

--- a/Scripts/verify-ccs22.sh
+++ b/Scripts/verify-ccs22.sh
@@ -18,6 +18,7 @@ fi
 rg -q 'SFSafariApplication\.showPreferencesForExtension\(withIdentifier: identifier' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "settings API wiring is missing"
 rg -q 'SFSafariExtensionManager\.getStateOfSafariExtension\(withIdentifier: identifier\)' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "state API wiring is missing"
 rg -q 'builtInPlugInsURL' CurrencyConverter/SafariExtensionSettingsAdapter.swift || fail "configured embedded extension lookup is missing"
+rg -q 'NSApplication\.didBecomeActiveNotification' CurrencyConverter/ContentView.swift || fail "state is not refreshed when the user returns from Safari"
 if rg -q 'com\.rayer\.CurrencyConverter-Extension' CurrencyConverter Shared; then
     fail "extension bundle identifier is duplicated in Swift"
 fi

--- a/Shared/SafariExtensionSettingsState.swift
+++ b/Shared/SafariExtensionSettingsState.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+enum SafariExtensionSettingsStatus: Equatable {
+    case loading
+    case unknown
+    case enabled
+    case disabled
+    case error(String)
+}
+
+struct SafariExtensionSettingsCopy: Equatable {
+    let actionTitle: String
+    let statusText: String
+    let accessibilityValue: String
+    let accessibilityHint: String
+}
+
+enum SafariExtensionSettingsCopyMapping {
+    static let actionTitle = "Open Safari Extension Settings"
+    static let accessibilityHint = "Opens Safari settings for this extension. Enable or disable it there."
+
+    static func copy(for status: SafariExtensionSettingsStatus) -> SafariExtensionSettingsCopy {
+        let statusText: String
+        let accessibilityValue: String
+
+        switch status {
+        case .loading:
+            statusText = "Checking extension status…"
+            accessibilityValue = "Checking."
+        case .unknown:
+            statusText = "Extension status is unavailable. Check Safari Extension Settings."
+            accessibilityValue = "Unknown."
+        case .enabled:
+            statusText = "Extension is enabled."
+            accessibilityValue = "Enabled."
+        case .disabled:
+            statusText = "Extension is disabled. Enable it in Safari Extension Settings."
+            accessibilityValue = "Disabled."
+        case .error(let message):
+            let detail = message.isEmpty ? "Safari did not provide more details." : message
+            statusText = "Extension settings error: \(detail)"
+            accessibilityValue = "Error. \(detail)"
+        }
+
+        return SafariExtensionSettingsCopy(
+            actionTitle: actionTitle,
+            statusText: statusText,
+            accessibilityValue: accessibilityValue,
+            accessibilityHint: accessibilityHint
+        )
+    }
+}
+
+enum SafariExtensionSettingsResult: Equatable {
+    case status(SafariExtensionSettingsStatus)
+    case failure(String)
+}
+
+struct SafariExtensionSettingsStateMachine {
+    private(set) var status: SafariExtensionSettingsStatus = .loading
+    private(set) var generation: UInt = 0
+
+    mutating func beginRefresh() -> UInt {
+        generation &+= 1
+        status = .loading
+        return generation
+    }
+
+    mutating func beginHandoff() -> UInt {
+        generation &+= 1
+        return generation
+    }
+
+    @discardableResult
+    mutating func apply(_ result: SafariExtensionSettingsResult, for generation: UInt) -> Bool {
+        guard generation == self.generation else { return false }
+
+        switch result {
+        case .status(let status):
+            self.status = status
+        case .failure(let message):
+            self.status = .error(message)
+        }
+        return true
+    }
+}

--- a/Shared/SafariExtensionSettingsViewModel.swift
+++ b/Shared/SafariExtensionSettingsViewModel.swift
@@ -40,6 +40,7 @@ final class SafariExtensionSettingsViewModel: ObservableObject {
                         guard self.stateMachine.apply(.failure(errorMessage), for: generation) else { return }
                         self.publishCopy()
                     } else {
+                        guard self.stateMachine.generation == generation else { return }
                         self.refresh()
                     }
                 }

--- a/Shared/SafariExtensionSettingsViewModel.swift
+++ b/Shared/SafariExtensionSettingsViewModel.swift
@@ -1,0 +1,69 @@
+import Combine
+import Foundation
+
+protocol SafariExtensionSettingsProviding {
+    func fetchState(completion: @escaping (SafariExtensionSettingsResult) -> Void)
+    func openSettings(completion: @escaping (String?) -> Void)
+}
+
+final class SafariExtensionSettingsViewModel: ObservableObject {
+    @Published private(set) var copy = SafariExtensionSettingsCopyMapping.copy(for: .loading)
+
+    private let provider: SafariExtensionSettingsProviding
+    private var stateMachine = SafariExtensionSettingsStateMachine()
+
+    init(provider: SafariExtensionSettingsProviding) {
+        self.provider = provider
+    }
+
+    func refresh() {
+        onMain { [weak self] in
+            guard let self = self else { return }
+
+            let generation = self.stateMachine.beginRefresh()
+            self.publishCopy()
+            self.provider.fetchState { [weak self] result in
+                self?.apply(result, for: generation)
+            }
+        }
+    }
+
+    func openSettings() {
+        onMain { [weak self] in
+            guard let self = self else { return }
+
+            let generation = self.stateMachine.beginHandoff()
+            self.provider.openSettings { [weak self] errorMessage in
+                guard let self = self else { return }
+                self.onMain {
+                    if let errorMessage = errorMessage {
+                        guard self.stateMachine.apply(.failure(errorMessage), for: generation) else { return }
+                        self.publishCopy()
+                    } else {
+                        self.refresh()
+                    }
+                }
+            }
+        }
+    }
+
+    private func apply(_ result: SafariExtensionSettingsResult, for generation: UInt) {
+        onMain { [weak self] in
+            guard let self = self else { return }
+            guard self.stateMachine.apply(result, for: generation) else { return }
+            self.publishCopy()
+        }
+    }
+
+    private func publishCopy() {
+        copy = SafariExtensionSettingsCopyMapping.copy(for: stateMachine.status)
+    }
+
+    private func onMain(_ action: @escaping () -> Void) {
+        if Thread.isMainThread {
+            action()
+        } else {
+            DispatchQueue.main.async(execute: action)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Rename the action to `Open Safari Extension Settings`; the app never promises a direct toggle.
- Resolve the embedded extension bundle identifier from the built extension bundle instead of duplicating the configured identifier.
- Use supported SafariServices state/preferences APIs, show loading/unknown/enabled/disabled/error copy, publish callbacks on main, reject stale generations, and refresh when the app becomes active after Safari handoff.
- Align README installation steps with Safari manual enable/disable behavior.

## Evidence

- HEAD: `a770410`
- Immutable patch SHA-256: `fbbe7308d33be1bb7786c858350cff5d7021736c8de4c7d1220561e6fa6c6de0`; final fail-closed review pending.
- Focused XCTest: 4 passed.
- Full XCTest: 87 passed.
- Standalone state/copy/ViewModel/provider integration: 7 passed, including stale overlapping handoff success suppression.
- Same seven integration/state cases under Thread Sanitizer: passed, 0 warnings/races.
- App and embedded extension builds: passed.
- `Scripts/verify-ccs22.sh`: ownership, injection, generation guard, public API, exact embedded lookup, distinct app/test build-file IDs, target isolation and standalone checks passed.
- Project/plist/diff/GitGuardian checks passed.

## Manual limitation

The real Safari Settings handoff is interactive and was not automated. Runtime verification must be performed manually in Safari: launch the app, click `Open Safari Extension Settings`, enable/disable CurrencyConverter in Safari Settings > Extensions, return to the app, and observe the reported state. No private APIs or protected-consent automation are used.

Not merged.


